### PR TITLE
add MaintenanceLayout and StaffLayout components for client-side rendering

### DIFF
--- a/frontend/src/app/[locale]/maintenance/layout.tsx
+++ b/frontend/src/app/[locale]/maintenance/layout.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import MainLayout from "@/components/layout/MainLayout";
+
+export default function MaintenanceLayout({
+  children,
+}: {
+  readonly children: React.ReactNode;
+}) {
+  return <MainLayout>{children}</MainLayout>;
+}

--- a/frontend/src/app/[locale]/staff/layout.tsx
+++ b/frontend/src/app/[locale]/staff/layout.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import MainLayout from "@/components/layout/MainLayout";
+
+export default function StaffLayout({
+  children,
+}: {
+  readonly children: React.ReactNode;
+}) {
+  return <MainLayout>{children}</MainLayout>;
+}


### PR DESCRIPTION
This pull request introduces two new layout components for the `maintenance` and `staff` routes in the application. Both layouts ensure that their child components are wrapped with the common `MainLayout` component, promoting consistent structure and styling across these sections.

Layout component additions:

* Added `MaintenanceLayout` in `frontend/src/app/[locale]/maintenance/layout.tsx` to wrap maintenance-related pages with `MainLayout`. ([frontend/src/app/[locale]/maintenance/layout.tsxR1-R11](diffhunk://#diff-47d2a49b8934d329f96a86632081e59207c07cf38a471fa7b1cdce888983c49cR1-R11))
* Added `StaffLayout` in `frontend/src/app/[locale]/staff/layout.tsx` to wrap staff-related pages with `MainLayout`. ([frontend/src/app/[locale]/staff/layout.tsxR1-R11](diffhunk://#diff-4094493b7df8808fd29c5d41b6aef1b4c2abd0d912e55b36fc5eb38d94ecc2d6R1-R11))