### PR TITLE
fix(template-editor): remove role and aria-multiline from editor div for accessibility improvements

### DIFF
--- a/frontend/src/app/[locale]/templates/editor/page.tsx
+++ b/frontend/src/app/[locale]/templates/editor/page.tsx
@@ -331,9 +331,7 @@ function TemplateEditorContent({
           </div>
 
           <div
-            role="textbox"
             aria-label={t("bodyPlaceholder")}
-            aria-multiline={true}
             tabIndex={0}
             ref={editorRef}
             contentEditable

--- a/frontend/src/components/properties/PropertyForm.tsx
+++ b/frontend/src/components/properties/PropertyForm.tsx
@@ -318,8 +318,8 @@ export function PropertyForm({
     setSubmitErrorMessage(tValidation("required"));
   };
 
-  const handleFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    void handleSubmit(onSubmit, onInvalid)(event);
+  const handleFormSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    await handleSubmit(onSubmit, onInvalid)(event);
   };
 
   const handleImageUpload = async (file: File) => {


### PR DESCRIPTION
This pull request includes minor improvements to accessibility and form submission handling in the codebase.

Accessibility and semantics:

* Removed the `role="textbox"` and `aria-multiline={true}` attributes from the editable div in `page.tsx` to clean up redundant or unnecessary ARIA attributes. ([frontend/src/app/[locale]/templates/editor/page.tsxL334-L336](diffhunk://#diff-70f9195615185165aab7dae9d680fec3550966e74becb0e60cadd75873a676ebL334-L336))

Form handling:

* Updated the `handleFormSubmit` function in `PropertyForm.tsx` to be `async` and use `await` for `handleSubmit`, ensuring proper handling of asynchronous form submission.