### PR TITLE
Improve accessibility by removing roles from editor div

### DIFF
--- a/frontend/src/app/[locale]/templates/editor/page.tsx
+++ b/frontend/src/app/[locale]/templates/editor/page.tsx
@@ -331,9 +331,7 @@ function TemplateEditorContent({
           </div>
 
           <div
-            role="textbox"
             aria-label={t("bodyPlaceholder")}
-            aria-multiline={true}
             tabIndex={0}
             ref={editorRef}
             contentEditable

--- a/frontend/src/components/properties/PropertyForm.tsx
+++ b/frontend/src/components/properties/PropertyForm.tsx
@@ -318,8 +318,8 @@ export function PropertyForm({
     setSubmitErrorMessage(tValidation("required"));
   };
 
-  const handleFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    void handleSubmit(onSubmit, onInvalid)(event);
+  const handleFormSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    await handleSubmit(onSubmit, onInvalid)(event);
   };
 
   const handleImageUpload = async (file: File) => {


### PR DESCRIPTION
This pull request makes two minor changes to improve accessibility and code clarity. The first change removes unnecessary ARIA attributes from a div that is already content-editable, and the second updates a form submission handler to use `async/await` for better error handling.

Accessibility improvements:
* Removed redundant `role="textbox"` and `aria-multiline={true}` attributes from the content-editable div in `page.tsx`, as the element is already accessible due to `contentEditable`. ([frontend/src/app/[locale]/templates/editor/page.tsxL334-L336](diffhunk://#diff-70f9195615185165aab7dae9d680fec3550966e74becb0e60cadd75873a676ebL334-L336))

Code clarity:
* Updated `handleFormSubmit` in `PropertyForm.tsx` to use `async/await` instead of `void` for handling form submission, improving readability and consistency with async functions.