### PR TITLE
Fix deployment process and CI job for backend build output

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -79,6 +79,20 @@
       ansible.builtin.command:
         cmd: npm run build
         chdir: "{{ current_path }}/backend"
+      register: backend_build
+
+    - name: Check backend build output exists
+      ansible.builtin.stat:
+        path: "{{ current_path }}/backend/dist/main.js"
+      register: backend_dist
+
+    - name: Fail if backend build output is missing
+      ansible.builtin.fail:
+        msg: >-
+          Backend build completed but dist/main.js was not found.
+          Build output: {{ backend_build.stdout }}
+          Build stderr: {{ backend_build.stderr }}
+      when: not backend_dist.stat.exists
 
     - name: Prune backend dev dependencies
       ansible.builtin.command:

--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -3,7 +3,6 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true,
     "assets": [
       {
         "include": "i18n/**/*",


### PR DESCRIPTION
This pull request introduces improvements to the backend build process by adding a verification step to ensure the build output exists and makes a minor configuration change in the NestJS CLI settings.

**Backend build process improvements:**
* Added Ansible tasks in `ansible/deploy.yml` to check for the existence of `dist/main.js` after running the backend build, and to fail the deployment with a helpful error message if the file is missing. This helps catch build failures early and provides clearer feedback.

**NestJS CLI configuration:**
* Removed the `deleteOutDir` option from the `compilerOptions` section in `backend/nest-cli.json`.