### PR TITLE
Fix backend deployment process and CI job for build output

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -69,6 +69,7 @@
       loop:
         - "{{ current_path }}/backend/node_modules"
         - "{{ current_path }}/backend/dist"
+        - "{{ current_path }}/backend/tsconfig.build.tsbuildinfo"
 
     - name: Install backend dependencies
       ansible.builtin.command:
@@ -149,6 +150,7 @@
       loop:
         - "{{ current_path }}/batch/node_modules"
         - "{{ current_path }}/batch/dist"
+        - "{{ current_path }}/batch/tsconfig.build.tsbuildinfo"
 
     - name: Install batch dependencies
       ansible.builtin.command:
@@ -232,6 +234,13 @@
         state: link
         force: true
 
+    - name: Create frontend symlink newrelic.js
+      ansible.builtin.file:
+        src: "{{ current_path }}/frontend/newrelic.js"
+        dest: "{{ deploy_path }}/frontend/newrelic.js"
+        state: link
+        force: true
+
     - name: Link shared .env to frontend root
       ansible.builtin.file:
         src: "{{ deploy_path }}/shared/.env"
@@ -290,8 +299,9 @@
           --log /var/log/rent/frontend.log
           --time
           -- start --dotenv_config_path={{ deploy_path }}/frontend/.env
+        chdir: "{{ deploy_path }}/frontend"
       environment:
-        NODE_OPTIONS: "-r ./newrelic.js -r newrelic"
+        NODE_OPTIONS: "-r {{ deploy_path }}/frontend/newrelic.js -r newrelic"
 
     - name: Save PM2 process list
       ansible.builtin.command:

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -99,6 +99,19 @@
         cmd: npm prune --omit=dev
         chdir: "{{ current_path }}/backend"
 
+    - name: Check deployed backend path
+      ansible.builtin.stat:
+        path: "{{ deploy_path }}/backend"
+      register: deployed_backend_path
+
+    - name: Remove stale backend deploy directory before linking build output
+      ansible.builtin.file:
+        path: "{{ deploy_path }}/backend"
+        state: absent
+      when:
+        - deployed_backend_path.stat.exists
+        - not deployed_backend_path.stat.islnk
+
     - name: Create backend symlink
       ansible.builtin.file:
         src: "{{ current_path }}/backend/dist"
@@ -112,6 +125,19 @@
         dest: "{{ current_path }}/backend/dist/.env"
         state: link
         force: true
+
+    - name: Check deployed backend entrypoint exists
+      ansible.builtin.stat:
+        path: "{{ deploy_path }}/backend/main.js"
+      register: deployed_backend_entrypoint
+
+    - name: Fail if deployed backend entrypoint is missing
+      ansible.builtin.fail:
+        msg: >-
+          Backend deploy symlink is not pointing at a build with main.js.
+          Expected {{ deploy_path }}/backend/main.js to exist.
+          Build output path: {{ current_path }}/backend/dist/main.js.
+      when: not deployed_backend_entrypoint.stat.exists
 
     # ─────────────────────────────────────────────────────────────
     # BATCH BUILD


### PR DESCRIPTION
This pull request updates the deployment process in `ansible/deploy.yml` to improve robustness, ensure correct linking of build artifacts, and add better validation and observability for the backend, batch, and frontend services.

**Backend deployment improvements:**

* Added a step to check for and remove a stale `backend` deploy directory before creating the symlink, ensuring a clean deployment and avoiding issues with leftover files (`ansible/deploy.yml`).
* Added validation to fail the deployment if the backend entrypoint (`main.js`) is missing after symlinking, preventing incomplete or broken deployments (`ansible/deploy.yml`).

**Build artifact cleanup:**

* Updated the cleanup steps to also remove `tsconfig.build.tsbuildinfo` for both backend and batch, ensuring no stale TypeScript build info files remain between deploys (`ansible/deploy.yml`). [[1]](diffhunk://#diff-83efaa4b3f30584c15a7040620863d596818732916afa6870b9f534bf55c78a0R72) [[2]](diffhunk://#diff-83efaa4b3f30584c15a7040620863d596818732916afa6870b9f534bf55c78a0R153)

**Frontend deployment and observability:**

* Added a task to symlink `newrelic.js` into the frontend deploy directory, ensuring observability tooling is correctly referenced (`ansible/deploy.yml`).
* Updated the PM2 start command for the frontend to use the symlinked `newrelic.js` from the deploy path, ensuring correct instrumentation at runtime (`ansible/deploy.yml`).