### PR TITLE
Fix code scanning alerts

### DIFF
--- a/backend/src/ai/ai-tool-executor.service.ts
+++ b/backend/src/ai/ai-tool-executor.service.ts
@@ -15,6 +15,11 @@ import {
 @Injectable()
 export class AiToolExecutorService {
   private readonly logger = new Logger(AiToolExecutorService.name);
+  private readonly unsafeObjectKeys = new Set([
+    '__proto__',
+    'constructor',
+    'prototype',
+  ]);
 
   constructor(private readonly catalog: AiToolCatalogService) {}
 
@@ -100,20 +105,11 @@ export class AiToolExecutorService {
     }
 
     if (value && typeof value === 'object') {
-      const output: Record<string, unknown> = Object.create(null);
-      for (const [key, val] of Object.entries(
-        value as Record<string, unknown>,
-      )) {
-        if (
-          key === '__proto__' ||
-          key === 'constructor' ||
-          key === 'prototype'
-        ) {
-          continue;
-        }
-        output[key] = this.nullsToUndefined(val);
-      }
-      return output;
+      return Object.fromEntries(
+        Object.entries(value as Record<string, unknown>)
+          .filter(([key]) => !this.unsafeObjectKeys.has(key))
+          .map(([key, val]) => [key, this.nullsToUndefined(val)]),
+      );
     }
 
     return value;
@@ -159,16 +155,11 @@ export class AiToolExecutorService {
     }
 
     if (value && typeof value === 'object') {
-      const output: Record<string, unknown> = {};
-      for (const [key, val] of Object.entries(
-        value as Record<string, unknown>,
-      )) {
-        if (blockedKeys.has(key)) {
-          continue;
-        }
-        output[key] = this.sanitizeOutput(val);
-      }
-      return output;
+      return Object.fromEntries(
+        Object.entries(value as Record<string, unknown>)
+          .filter(([key]) => !blockedKeys.has(key))
+          .map(([key, val]) => [key, this.sanitizeOutput(val)]),
+      );
     }
 
     return value;

--- a/backend/src/whatsapp/whatsapp.controller.spec.ts
+++ b/backend/src/whatsapp/whatsapp.controller.spec.ts
@@ -68,14 +68,32 @@ describe('WhatsappController', () => {
       {
         'hub.mode': 'subscribe',
         'hub.verify_token': 'verify',
-        'hub.challenge': 'challenge-1',
+        'hub.challenge': '123456',
       } as any,
       res,
     );
 
     expect(res.type).toHaveBeenCalledWith('text/plain');
     expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
-    expect(res.send).toHaveBeenCalledWith('challenge-1');
+    expect(res.send).toHaveBeenCalledWith('123456');
+  });
+
+  it('verifyWebhook rejects non-numeric challenge values', () => {
+    const res = {
+      sendStatus: jest.fn().mockReturnThis(),
+    } as any;
+
+    controller.verifyWebhook(
+      {
+        'hub.mode': 'subscribe',
+        'hub.verify_token': 'verify',
+        'hub.challenge': '<script>alert(1)</script>',
+      } as any,
+      res,
+    );
+
+    expect(whatsappService.verifyWebhookToken).not.toHaveBeenCalled();
+    expect(res.sendStatus).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
   });
 
   it('verifyWebhook returns forbidden when token is invalid', () => {
@@ -90,7 +108,7 @@ describe('WhatsappController', () => {
       {
         'hub.mode': 'subscribe',
         'hub.verify_token': 'wrong',
-        'hub.challenge': 'challenge-1',
+        'hub.challenge': '123456',
       } as any,
       res,
     );

--- a/backend/src/whatsapp/whatsapp.controller.ts
+++ b/backend/src/whatsapp/whatsapp.controller.ts
@@ -50,7 +50,7 @@ export class WhatsappController {
     const challenge = query['hub.challenge'];
 
     const isValidChallenge =
-      typeof challenge === 'string' && /^[A-Za-z0-9_-]{1,200}$/.test(challenge);
+      typeof challenge === 'string' && /^\d{1,32}$/.test(challenge);
 
     if (!isValidChallenge) {
       return res.sendStatus(HttpStatus.BAD_REQUEST);

--- a/frontend/src/app/[locale]/leases/[id]/page.tsx
+++ b/frontend/src/app/[locale]/leases/[id]/page.tsx
@@ -690,12 +690,13 @@ function LeaseDocumentsSection({
           <ul className="space-y-2">
             {lease.documents.map((doc, index) => {
               const safeHref = getSafeDocumentHref(doc);
+              const documentHref = safeHref ? encodeURI(safeHref) : null;
 
               return (
                 <li key={doc}>
-                  {safeHref ? (
+                  {documentHref ? (
                     <a
-                      href={safeHref}
+                      href={documentHref}
                       className="flex items-center text-blue-600 hover:underline"
                     >
                       <FileText size={16} className="mr-2" />

--- a/frontend/src/app/[locale]/leases/page.tsx
+++ b/frontend/src/app/[locale]/leases/page.tsx
@@ -9,7 +9,6 @@ import { useLocale, useTranslations } from "next-intl";
 import { useAuth } from "@/contexts/auth-context";
 import { formatMoneyByCode } from "@/lib/format-money";
 import { normalizeSearchText } from "@/lib/search";
-import { encodeRouteSegment } from "@/lib/safe-url";
 
 function normalizeDate(value?: string): Date | null {
   if (!value) return null;
@@ -53,76 +52,82 @@ function LeaseSection({
         <p className="text-sm text-slate-500 dark:text-slate-400">{subtitle}</p>
       </div>
       <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
-        {leases.map((lease) => (
-          <Link
-            key={lease.id}
-            href={`/${locale}/leases/${encodeRouteSegment(lease.id)}`}
-            className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-slate-800 dark:bg-slate-900"
-          >
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <p className="text-lg font-semibold text-slate-900 dark:text-white">
-                  {lease.property?.name ?? "Propiedad sin nombre"}
-                </p>
-                <p className="text-sm text-slate-500 dark:text-slate-400">
-                  {`${lease.tenant?.firstName ?? ""} ${lease.tenant?.lastName ?? ""}`.trim() ||
-                    "Sin inquilino"}
-                </p>
-              </div>
-              <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-[0.16em] text-slate-600 dark:bg-slate-800 dark:text-slate-300">
-                {lease.status}
-              </span>
-            </div>
+        {leases.map((lease) => {
+          const leaseHref = `/${encodeURIComponent(locale)}/leases/${encodeURIComponent(
+            lease.id,
+          )}`;
 
-            <div className="mt-4 grid gap-3 sm:grid-cols-3">
-              <div>
+          return (
+            <Link
+              key={lease.id}
+              href={leaseHref}
+              className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-slate-800 dark:bg-slate-900"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="text-lg font-semibold text-slate-900 dark:text-white">
+                    {lease.property?.name ?? "Propiedad sin nombre"}
+                  </p>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    {`${lease.tenant?.firstName ?? ""} ${lease.tenant?.lastName ?? ""}`.trim() ||
+                      "Sin inquilino"}
+                  </p>
+                </div>
+                <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-[0.16em] text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                  {lease.status}
+                </span>
+              </div>
+
+              <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.16em] text-slate-400">
+                    Inicio
+                  </p>
+                  <p className="text-sm text-slate-700 dark:text-slate-200">
+                    {lease.startDate
+                      ? new Date(lease.startDate).toLocaleDateString(locale)
+                      : "-"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-[0.16em] text-slate-400">
+                    Fin
+                  </p>
+                  <p className="text-sm text-slate-700 dark:text-slate-200">
+                    {lease.endDate
+                      ? new Date(lease.endDate).toLocaleDateString(locale)
+                      : "-"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-[0.16em] text-slate-400">
+                    Canon
+                  </p>
+                  <p className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                    {lease.rentAmount === undefined
+                      ? "-"
+                      : formatMoneyByCode(
+                          lease.rentAmount,
+                          lease.currency,
+                          locale,
+                        )}
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-4 rounded-2xl bg-slate-50 p-3 dark:bg-slate-950">
                 <p className="text-xs uppercase tracking-[0.16em] text-slate-400">
-                  Inicio
+                  Alertas de renovación
                 </p>
                 <p className="text-sm text-slate-700 dark:text-slate-200">
-                  {lease.startDate
-                    ? new Date(lease.startDate).toLocaleDateString(locale)
-                    : "-"}
+                  {lease.renewalAlertEnabled
+                    ? `Activas · ${lease.renewalAlertPeriodicity ?? "monthly"}`
+                    : "Desactivadas"}
                 </p>
               </div>
-              <div>
-                <p className="text-xs uppercase tracking-[0.16em] text-slate-400">
-                  Fin
-                </p>
-                <p className="text-sm text-slate-700 dark:text-slate-200">
-                  {lease.endDate
-                    ? new Date(lease.endDate).toLocaleDateString(locale)
-                    : "-"}
-                </p>
-              </div>
-              <div>
-                <p className="text-xs uppercase tracking-[0.16em] text-slate-400">
-                  Canon
-                </p>
-                <p className="text-sm font-medium text-slate-700 dark:text-slate-200">
-                  {lease.rentAmount === undefined
-                    ? "-"
-                    : formatMoneyByCode(
-                        lease.rentAmount,
-                        lease.currency,
-                        locale,
-                      )}
-                </p>
-              </div>
-            </div>
-
-            <div className="mt-4 rounded-2xl bg-slate-50 p-3 dark:bg-slate-950">
-              <p className="text-xs uppercase tracking-[0.16em] text-slate-400">
-                Alertas de renovación
-              </p>
-              <p className="text-sm text-slate-700 dark:text-slate-200">
-                {lease.renewalAlertEnabled
-                  ? `Activas · ${lease.renewalAlertPeriodicity ?? "monthly"}`
-                  : "Desactivadas"}
-              </p>
-            </div>
-          </Link>
-        ))}
+            </Link>
+          );
+        })}
       </div>
     </section>
   );

--- a/frontend/src/app/[locale]/settings/page.tsx
+++ b/frontend/src/app/[locale]/settings/page.tsx
@@ -4,7 +4,7 @@ import { SyntheticEvent, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { ArrowLeft, Loader2, Lock, Save } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import type { Locale } from "@/config/locales";
 import { useAuth } from "@/contexts/auth-context";
 import { usersApi } from "@/lib/api/users";
@@ -45,6 +45,7 @@ export default function SettingsPage() {
   const { user, loading: authLoading, updateUser } = useAuth();
   const locale = useLocale() as Locale;
   const pathname = usePathname();
+  const router = useRouter();
   const t = useTranslations("userSettings");
   const tCommon = useTranslations("common");
   const tAuth = useTranslations("auth");
@@ -146,10 +147,7 @@ export default function SettingsPage() {
 
       if (profileForm.language !== locale) {
         const nextPath = getPathForLocale(profileForm.language);
-        const nextUrl = new URL(nextPath, globalThis.location.origin);
-        globalThis.location.assign(
-          `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`,
-        );
+        router.replace(nextPath);
         return;
       }
     } catch (error) {

--- a/frontend/src/lib/safe-url.spec.ts
+++ b/frontend/src/lib/safe-url.spec.ts
@@ -30,6 +30,9 @@ describe("safe-url helpers", () => {
     expect(getSafeDocumentHref("/documents/contract.pdf")).toBe(
       "/documents/contract.pdf",
     );
+    expect(getSafeDocumentHref("/documents/contract.pdf?name=<script>")).toBe(
+      "/documents/contract.pdf?name=%3Cscript%3E",
+    );
     expect(getSafeDocumentHref("https://example.com/document.pdf")).toBe(
       "https://example.com/document.pdf",
     );

--- a/frontend/src/lib/safe-url.ts
+++ b/frontend/src/lib/safe-url.ts
@@ -1,4 +1,5 @@
 type QueryValue = string | number | boolean | null | undefined;
+const DOCUMENT_URL_BASE = "https://rent.local";
 
 export function encodeRouteSegment(value: string | number): string {
   return encodeURIComponent(String(value));
@@ -21,7 +22,8 @@ export function buildPathWithQuery(
 
 export function getSafeDocumentHref(value: string): string | null {
   if (value.startsWith("/") && !value.startsWith("//")) {
-    return value;
+    const url = new URL(value, DOCUMENT_URL_BASE);
+    return `${url.pathname}${url.search}${url.hash}`;
   }
 
   try {


### PR DESCRIPTION
## Summary\n- Harden WhatsApp webhook challenge validation before echoing it as text/plain\n- Avoid dynamic object property writes while normalizing AI tool args\n- Encode and sanitize frontend navigation/document href values used in DOM sinks\n\n## Verification\n- frontend: npm test -- --runTestsByPath src/lib/safe-url.spec.ts\n- frontend: npm run type-check\n- frontend: npm run lint\n- backend: npm test -- --runTestsByPath src/whatsapp/whatsapp.controller.spec.ts src/ai/ai-tool-executor.service.spec.ts\n- backend: npm run type-check\n- backend: npm run lint -- --fix=false