### PR TITLE
Fix backend deployment process and improve code quality

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -69,6 +69,7 @@
       loop:
         - "{{ current_path }}/backend/node_modules"
         - "{{ current_path }}/backend/dist"
+        - "{{ current_path }}/backend/tsconfig.build.tsbuildinfo"
 
     - name: Install backend dependencies
       ansible.builtin.command:
@@ -149,6 +150,7 @@
       loop:
         - "{{ current_path }}/batch/node_modules"
         - "{{ current_path }}/batch/dist"
+        - "{{ current_path }}/batch/tsconfig.build.tsbuildinfo"
 
     - name: Install batch dependencies
       ansible.builtin.command:
@@ -232,6 +234,13 @@
         state: link
         force: true
 
+    - name: Create frontend symlink newrelic.js
+      ansible.builtin.file:
+        src: "{{ current_path }}/frontend/newrelic.js"
+        dest: "{{ deploy_path }}/frontend/newrelic.js"
+        state: link
+        force: true
+
     - name: Link shared .env to frontend root
       ansible.builtin.file:
         src: "{{ deploy_path }}/shared/.env"
@@ -290,8 +299,9 @@
           --log /var/log/rent/frontend.log
           --time
           -- start --dotenv_config_path={{ deploy_path }}/frontend/.env
+        chdir: "{{ deploy_path }}/frontend"
       environment:
-        NODE_OPTIONS: "-r ./newrelic.js -r newrelic"
+        NODE_OPTIONS: "-r {{ deploy_path }}/frontend/newrelic.js -r newrelic"
 
     - name: Save PM2 process list
       ansible.builtin.command:

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -99,6 +99,19 @@
         cmd: npm prune --omit=dev
         chdir: "{{ current_path }}/backend"
 
+    - name: Check deployed backend path
+      ansible.builtin.stat:
+        path: "{{ deploy_path }}/backend"
+      register: deployed_backend_path
+
+    - name: Remove stale backend deploy directory before linking build output
+      ansible.builtin.file:
+        path: "{{ deploy_path }}/backend"
+        state: absent
+      when:
+        - deployed_backend_path.stat.exists
+        - not deployed_backend_path.stat.islnk
+
     - name: Create backend symlink
       ansible.builtin.file:
         src: "{{ current_path }}/backend/dist"
@@ -112,6 +125,19 @@
         dest: "{{ current_path }}/backend/dist/.env"
         state: link
         force: true
+
+    - name: Check deployed backend entrypoint exists
+      ansible.builtin.stat:
+        path: "{{ deploy_path }}/backend/main.js"
+      register: deployed_backend_entrypoint
+
+    - name: Fail if deployed backend entrypoint is missing
+      ansible.builtin.fail:
+        msg: >-
+          Backend deploy symlink is not pointing at a build with main.js.
+          Expected {{ deploy_path }}/backend/main.js to exist.
+          Build output path: {{ current_path }}/backend/dist/main.js.
+      when: not deployed_backend_entrypoint.stat.exists
 
     # ─────────────────────────────────────────────────────────────
     # BATCH BUILD

--- a/backend/src/ai/ai-tool-executor.service.ts
+++ b/backend/src/ai/ai-tool-executor.service.ts
@@ -15,6 +15,11 @@ import {
 @Injectable()
 export class AiToolExecutorService {
   private readonly logger = new Logger(AiToolExecutorService.name);
+  private readonly unsafeObjectKeys = new Set([
+    '__proto__',
+    'constructor',
+    'prototype',
+  ]);
 
   constructor(private readonly catalog: AiToolCatalogService) {}
 
@@ -100,20 +105,11 @@ export class AiToolExecutorService {
     }
 
     if (value && typeof value === 'object') {
-      const output: Record<string, unknown> = Object.create(null);
-      for (const [key, val] of Object.entries(
-        value as Record<string, unknown>,
-      )) {
-        if (
-          key === '__proto__' ||
-          key === 'constructor' ||
-          key === 'prototype'
-        ) {
-          continue;
-        }
-        output[key] = this.nullsToUndefined(val);
-      }
-      return output;
+      return Object.fromEntries(
+        Object.entries(value as Record<string, unknown>)
+          .filter(([key]) => !this.unsafeObjectKeys.has(key))
+          .map(([key, val]) => [key, this.nullsToUndefined(val)]),
+      );
     }
 
     return value;
@@ -159,16 +155,11 @@ export class AiToolExecutorService {
     }
 
     if (value && typeof value === 'object') {
-      const output: Record<string, unknown> = {};
-      for (const [key, val] of Object.entries(
-        value as Record<string, unknown>,
-      )) {
-        if (blockedKeys.has(key)) {
-          continue;
-        }
-        output[key] = this.sanitizeOutput(val);
-      }
-      return output;
+      return Object.fromEntries(
+        Object.entries(value as Record<string, unknown>)
+          .filter(([key]) => !blockedKeys.has(key))
+          .map(([key, val]) => [key, this.sanitizeOutput(val)]),
+      );
     }
 
     return value;

--- a/backend/src/whatsapp/whatsapp.controller.spec.ts
+++ b/backend/src/whatsapp/whatsapp.controller.spec.ts
@@ -68,14 +68,32 @@ describe('WhatsappController', () => {
       {
         'hub.mode': 'subscribe',
         'hub.verify_token': 'verify',
-        'hub.challenge': 'challenge-1',
+        'hub.challenge': '123456',
       } as any,
       res,
     );
 
     expect(res.type).toHaveBeenCalledWith('text/plain');
     expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
-    expect(res.send).toHaveBeenCalledWith('challenge-1');
+    expect(res.send).toHaveBeenCalledWith('123456');
+  });
+
+  it('verifyWebhook rejects non-numeric challenge values', () => {
+    const res = {
+      sendStatus: jest.fn().mockReturnThis(),
+    } as any;
+
+    controller.verifyWebhook(
+      {
+        'hub.mode': 'subscribe',
+        'hub.verify_token': 'verify',
+        'hub.challenge': '<script>alert(1)</script>',
+      } as any,
+      res,
+    );
+
+    expect(whatsappService.verifyWebhookToken).not.toHaveBeenCalled();
+    expect(res.sendStatus).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
   });
 
   it('verifyWebhook returns forbidden when token is invalid', () => {
@@ -90,7 +108,7 @@ describe('WhatsappController', () => {
       {
         'hub.mode': 'subscribe',
         'hub.verify_token': 'wrong',
-        'hub.challenge': 'challenge-1',
+        'hub.challenge': '123456',
       } as any,
       res,
     );

--- a/backend/src/whatsapp/whatsapp.controller.ts
+++ b/backend/src/whatsapp/whatsapp.controller.ts
@@ -50,7 +50,7 @@ export class WhatsappController {
     const challenge = query['hub.challenge'];
 
     const isValidChallenge =
-      typeof challenge === 'string' && /^[A-Za-z0-9_-]{1,200}$/.test(challenge);
+      typeof challenge === 'string' && /^\d{1,32}$/.test(challenge);
 
     if (!isValidChallenge) {
       return res.sendStatus(HttpStatus.BAD_REQUEST);

--- a/frontend/src/app/[locale]/leases/[id]/page.tsx
+++ b/frontend/src/app/[locale]/leases/[id]/page.tsx
@@ -690,12 +690,13 @@ function LeaseDocumentsSection({
           <ul className="space-y-2">
             {lease.documents.map((doc, index) => {
               const safeHref = getSafeDocumentHref(doc);
+              const documentHref = safeHref ? encodeURI(safeHref) : null;
 
               return (
                 <li key={doc}>
-                  {safeHref ? (
+                  {documentHref ? (
                     <a
-                      href={safeHref}
+                      href={documentHref}
                       className="flex items-center text-blue-600 hover:underline"
                     >
                       <FileText size={16} className="mr-2" />

--- a/frontend/src/app/[locale]/leases/page.tsx
+++ b/frontend/src/app/[locale]/leases/page.tsx
@@ -9,7 +9,6 @@ import { useLocale, useTranslations } from "next-intl";
 import { useAuth } from "@/contexts/auth-context";
 import { formatMoneyByCode } from "@/lib/format-money";
 import { normalizeSearchText } from "@/lib/search";
-import { encodeRouteSegment } from "@/lib/safe-url";
 
 function normalizeDate(value?: string): Date | null {
   if (!value) return null;
@@ -53,76 +52,82 @@ function LeaseSection({
         <p className="text-sm text-slate-500 dark:text-slate-400">{subtitle}</p>
       </div>
       <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
-        {leases.map((lease) => (
-          <Link
-            key={lease.id}
-            href={`/${locale}/leases/${encodeRouteSegment(lease.id)}`}
-            className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-slate-800 dark:bg-slate-900"
-          >
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <p className="text-lg font-semibold text-slate-900 dark:text-white">
-                  {lease.property?.name ?? "Propiedad sin nombre"}
-                </p>
-                <p className="text-sm text-slate-500 dark:text-slate-400">
-                  {`${lease.tenant?.firstName ?? ""} ${lease.tenant?.lastName ?? ""}`.trim() ||
-                    "Sin inquilino"}
-                </p>
-              </div>
-              <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-[0.16em] text-slate-600 dark:bg-slate-800 dark:text-slate-300">
-                {lease.status}
-              </span>
-            </div>
+        {leases.map((lease) => {
+          const leaseHref = `/${encodeURIComponent(locale)}/leases/${encodeURIComponent(
+            lease.id,
+          )}`;
 
-            <div className="mt-4 grid gap-3 sm:grid-cols-3">
-              <div>
+          return (
+            <Link
+              key={lease.id}
+              href={leaseHref}
+              className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-slate-800 dark:bg-slate-900"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="text-lg font-semibold text-slate-900 dark:text-white">
+                    {lease.property?.name ?? "Propiedad sin nombre"}
+                  </p>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    {`${lease.tenant?.firstName ?? ""} ${lease.tenant?.lastName ?? ""}`.trim() ||
+                      "Sin inquilino"}
+                  </p>
+                </div>
+                <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-[0.16em] text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                  {lease.status}
+                </span>
+              </div>
+
+              <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.16em] text-slate-400">
+                    Inicio
+                  </p>
+                  <p className="text-sm text-slate-700 dark:text-slate-200">
+                    {lease.startDate
+                      ? new Date(lease.startDate).toLocaleDateString(locale)
+                      : "-"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-[0.16em] text-slate-400">
+                    Fin
+                  </p>
+                  <p className="text-sm text-slate-700 dark:text-slate-200">
+                    {lease.endDate
+                      ? new Date(lease.endDate).toLocaleDateString(locale)
+                      : "-"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-[0.16em] text-slate-400">
+                    Canon
+                  </p>
+                  <p className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                    {lease.rentAmount === undefined
+                      ? "-"
+                      : formatMoneyByCode(
+                          lease.rentAmount,
+                          lease.currency,
+                          locale,
+                        )}
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-4 rounded-2xl bg-slate-50 p-3 dark:bg-slate-950">
                 <p className="text-xs uppercase tracking-[0.16em] text-slate-400">
-                  Inicio
+                  Alertas de renovación
                 </p>
                 <p className="text-sm text-slate-700 dark:text-slate-200">
-                  {lease.startDate
-                    ? new Date(lease.startDate).toLocaleDateString(locale)
-                    : "-"}
+                  {lease.renewalAlertEnabled
+                    ? `Activas · ${lease.renewalAlertPeriodicity ?? "monthly"}`
+                    : "Desactivadas"}
                 </p>
               </div>
-              <div>
-                <p className="text-xs uppercase tracking-[0.16em] text-slate-400">
-                  Fin
-                </p>
-                <p className="text-sm text-slate-700 dark:text-slate-200">
-                  {lease.endDate
-                    ? new Date(lease.endDate).toLocaleDateString(locale)
-                    : "-"}
-                </p>
-              </div>
-              <div>
-                <p className="text-xs uppercase tracking-[0.16em] text-slate-400">
-                  Canon
-                </p>
-                <p className="text-sm font-medium text-slate-700 dark:text-slate-200">
-                  {lease.rentAmount === undefined
-                    ? "-"
-                    : formatMoneyByCode(
-                        lease.rentAmount,
-                        lease.currency,
-                        locale,
-                      )}
-                </p>
-              </div>
-            </div>
-
-            <div className="mt-4 rounded-2xl bg-slate-50 p-3 dark:bg-slate-950">
-              <p className="text-xs uppercase tracking-[0.16em] text-slate-400">
-                Alertas de renovación
-              </p>
-              <p className="text-sm text-slate-700 dark:text-slate-200">
-                {lease.renewalAlertEnabled
-                  ? `Activas · ${lease.renewalAlertPeriodicity ?? "monthly"}`
-                  : "Desactivadas"}
-              </p>
-            </div>
-          </Link>
-        ))}
+            </Link>
+          );
+        })}
       </div>
     </section>
   );

--- a/frontend/src/app/[locale]/leases/page.tsx
+++ b/frontend/src/app/[locale]/leases/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { Lease } from "@/types/lease";
 import { leasesApi } from "@/lib/api/leases";
 import { Search, Loader2 } from "lucide-react";
@@ -27,6 +28,8 @@ function LeaseSection({
   leases: Lease[];
   locale: string;
 }>) {
+  const router = useRouter();
+
   if (leases.length === 0) {
     return (
       <section className="rounded-3xl border border-dashed border-slate-300 bg-slate-50 p-5 dark:border-slate-700 dark:bg-slate-900/40">
@@ -58,10 +61,11 @@ function LeaseSection({
           )}`;
 
           return (
-            <Link
+            <button
+              type="button"
               key={lease.id}
-              href={leaseHref}
-              className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-slate-800 dark:bg-slate-900"
+              onClick={() => router.push(leaseHref)}
+              className="w-full rounded-3xl border border-slate-200 bg-white p-5 text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-slate-800 dark:bg-slate-900"
             >
               <div className="flex items-start justify-between gap-4">
                 <div>
@@ -125,7 +129,7 @@ function LeaseSection({
                     : "Desactivadas"}
                 </p>
               </div>
-            </Link>
+            </button>
           );
         })}
       </div>

--- a/frontend/src/app/[locale]/settings/page.tsx
+++ b/frontend/src/app/[locale]/settings/page.tsx
@@ -4,7 +4,7 @@ import { SyntheticEvent, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { ArrowLeft, Loader2, Lock, Save } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import type { Locale } from "@/config/locales";
 import { useAuth } from "@/contexts/auth-context";
 import { usersApi } from "@/lib/api/users";
@@ -45,6 +45,7 @@ export default function SettingsPage() {
   const { user, loading: authLoading, updateUser } = useAuth();
   const locale = useLocale() as Locale;
   const pathname = usePathname();
+  const router = useRouter();
   const t = useTranslations("userSettings");
   const tCommon = useTranslations("common");
   const tAuth = useTranslations("auth");
@@ -146,10 +147,7 @@ export default function SettingsPage() {
 
       if (profileForm.language !== locale) {
         const nextPath = getPathForLocale(profileForm.language);
-        const nextUrl = new URL(nextPath, globalThis.location.origin);
-        globalThis.location.assign(
-          `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`,
-        );
+        router.replace(nextPath);
         return;
       }
     } catch (error) {

--- a/frontend/src/lib/safe-url.spec.ts
+++ b/frontend/src/lib/safe-url.spec.ts
@@ -30,6 +30,9 @@ describe("safe-url helpers", () => {
     expect(getSafeDocumentHref("/documents/contract.pdf")).toBe(
       "/documents/contract.pdf",
     );
+    expect(getSafeDocumentHref("/documents/contract.pdf?name=<script>")).toBe(
+      "/documents/contract.pdf?name=%3Cscript%3E",
+    );
     expect(getSafeDocumentHref("https://example.com/document.pdf")).toBe(
       "https://example.com/document.pdf",
     );

--- a/frontend/src/lib/safe-url.ts
+++ b/frontend/src/lib/safe-url.ts
@@ -1,4 +1,5 @@
 type QueryValue = string | number | boolean | null | undefined;
+const DOCUMENT_URL_BASE = "https://rent.local";
 
 export function encodeRouteSegment(value: string | number): string {
   return encodeURIComponent(String(value));
@@ -21,7 +22,8 @@ export function buildPathWithQuery(
 
 export function getSafeDocumentHref(value: string): string | null {
   if (value.startsWith("/") && !value.startsWith("//")) {
-    return value;
+    const url = new URL(value, DOCUMENT_URL_BASE);
+    return `${url.pathname}${url.search}${url.hash}`;
   }
 
   try {


### PR DESCRIPTION
This pull request introduces several improvements across the deployment automation, backend security, and frontend navigation and URL handling. The most significant changes include enhanced deployment safety checks, improved object key filtering in the backend for security, stricter validation for WhatsApp webhook challenges, and safer handling of document URLs in the frontend. Additionally, navigation in the frontend has been modernized to use router methods instead of direct URL assignment.

**Deployment automation improvements:**
- Added checks and logic in `ansible/deploy.yml` to safely remove stale backend deploy directories before symlinking, and to fail fast if the backend build output is missing the `main.js` entrypoint. This helps prevent broken deployments and ensures the symlink always points to a valid build. [[1]](diffhunk://#diff-83efaa4b3f30584c15a7040620863d596818732916afa6870b9f534bf55c78a0R103-R115) [[2]](diffhunk://#diff-83efaa4b3f30584c15a7040620863d596818732916afa6870b9f534bf55c78a0R130-R142)
- Ensured `tsconfig.build.tsbuildinfo` files are cleaned for both backend and batch builds, and updated the frontend deployment to symlink `newrelic.js` correctly and set the proper `NODE_OPTIONS` path. [[1]](diffhunk://#diff-83efaa4b3f30584c15a7040620863d596818732916afa6870b9f534bf55c78a0R72) [[2]](diffhunk://#diff-83efaa4b3f30584c15a7040620863d596818732916afa6870b9f534bf55c78a0R153) [[3]](diffhunk://#diff-83efaa4b3f30584c15a7040620863d596818732916afa6870b9f534bf55c78a0R237-R243) [[4]](diffhunk://#diff-83efaa4b3f30584c15a7040620863d596818732916afa6870b9f534bf55c78a0R302-R304)

**Backend security and validation:**
- Refactored object key filtering in `AiToolExecutorService` to use a `Set` for blocked keys and `Object.fromEntries` for cleaner and more secure object construction, preventing prototype pollution. [[1]](diffhunk://#diff-b54b9be89edcc979b6b78dae2ad367919432da1d4047539e2ca07a3e310906fbR18-R22) [[2]](diffhunk://#diff-b54b9be89edcc979b6b78dae2ad367919432da1d4047539e2ca07a3e310906fbL103-R112) [[3]](diffhunk://#diff-b54b9be89edcc979b6b78dae2ad367919432da1d4047539e2ca07a3e310906fbL162-R162)
- Tightened WhatsApp webhook validation to only accept numeric `hub.challenge` values up to 32 digits, rejecting any non-numeric or potentially malicious input. Corresponding tests were updated and extended. [[1]](diffhunk://#diff-47661b0e63a1ba747be37e842100f4c6da6761a62b1c41d5bd85a23e42d84947L53-R53) [[2]](diffhunk://#diff-914f5685cf5ab51284cd5d7f9ff40d35e8e1865f177393c35c38ab17007f9858L71-R96) [[3]](diffhunk://#diff-914f5685cf5ab51284cd5d7f9ff40d35e8e1865f177393c35c38ab17007f9858L93-R111)

**Frontend navigation and URL safety:**
- Updated lease and settings pages to use Next.js router navigation (`router.push`/`router.replace`) instead of direct URL assignment, improving SPA navigation and user experience. ([frontend/src/app/[locale]/leases/page.tsxR5-L12](diffhunk://#diff-290283c0eefc43913ca7da3c3f4209498499d92414e1c7da5d6bbbfde6556345R5-L12), [frontend/src/app/[locale]/leases/page.tsxR31-R32](diffhunk://#diff-290283c0eefc43913ca7da3c3f4209498499d92414e1c7da5d6bbbfde6556345R31-R32), [frontend/src/app/[locale]/leases/page.tsxL56-R68](diffhunk://#diff-290283c0eefc43913ca7da3c3f4209498499d92414e1c7da5d6bbbfde6556345L56-R68), [frontend/src/app/[locale]/leases/page.tsxL124-R134](diffhunk://#diff-290283c0eefc43913ca7da3c3f4209498499d92414e1c7da5d6bbbfde6556345L124-R134), [frontend/src/app/[locale]/settings/page.tsxL7-R7](diffhunk://#diff-a33e786c22d3816a9086324a43210b6901c6b924475c09e0317a8fdb3365c664L7-R7), [frontend/src/app/[locale]/settings/page.tsxR48](diffhunk://#diff-a33e786c22d3816a9086324a43210b6901c6b924475c09e0317a8fdb3365c664R48), [frontend/src/app/[locale]/settings/page.tsxL149-R150](diffhunk://#diff-a33e786c22d3816a9086324a43210b6901c6b924475c09e0317a8fdb3365c664L149-R150))
- Improved document URL handling by ensuring query parameters are properly encoded in `getSafeDocumentHref`, preventing XSS risks from unescaped input. Tests were added to cover these cases. ([frontend/src/app/[locale]/leases/[id]/page.tsxR693-R699](diffhunk://#diff-d8357e8290db61d6670c32405377fbd19786bb19f088c0ef232bf45ea8dcd803R693-R699), [[1]](diffhunk://#diff-802d02c0ab87ec8dc90f7187cb97a561971bd6ec07c7c93e22affede6aecf53aR2) [[2]](diffhunk://#diff-802d02c0ab87ec8dc90f7187cb97a561971bd6ec07c7c93e22affede6aecf53aL24-R26) [[3]](diffhunk://#diff-69b250d975e0080872527f02e5943a0c82a9bb3ce55756626c3ce913e52516ccR33-R35)