### PR TITLE
Fix WhatsApp webhook verification aliases

### DIFF
--- a/backend/src/whatsapp/dto/whatsapp-webhook-query.dto.ts
+++ b/backend/src/whatsapp/dto/whatsapp-webhook-query.dto.ts
@@ -3,11 +3,39 @@ import { z } from 'zod';
 
 const whatsappWebhookQueryZodSchema = z
   .object({
-    'hub.mode': z.string().min(1),
-    'hub.verify_token': z.string().min(1),
-    'hub.challenge': z.string().min(1),
+    'hub.mode': z.string().min(1).optional(),
+    'hub.verify_token': z.string().min(1).optional(),
+    'hub.challenge': z.string().min(1).optional(),
+    hub_mode: z.string().min(1).optional(),
+    hub_verify_token: z.string().min(1).optional(),
+    hub_challenge: z.string().min(1).optional(),
   })
-  .strict();
+  .strict()
+  .transform((query, ctx) => {
+    const mode = query['hub.mode'] ?? query.hub_mode;
+    const verifyToken = query['hub.verify_token'] ?? query.hub_verify_token;
+    const challenge = query['hub.challenge'] ?? query.hub_challenge;
+
+    for (const [key, value] of [
+      ['hub.mode', mode],
+      ['hub.verify_token', verifyToken],
+      ['hub.challenge', challenge],
+    ] as const) {
+      if (!value) {
+        ctx.addIssue({
+          code: 'custom',
+          path: [key],
+          message: 'Required',
+        });
+      }
+    }
+
+    return {
+      'hub.mode': mode,
+      'hub.verify_token': verifyToken,
+      'hub.challenge': challenge,
+    };
+  });
 
 export class WhatsappWebhookQueryDto {
   static readonly zodSchema = whatsappWebhookQueryZodSchema;

--- a/backend/src/whatsapp/whatsapp.controller.spec.ts
+++ b/backend/src/whatsapp/whatsapp.controller.spec.ts
@@ -1,4 +1,5 @@
 import { ForbiddenException, HttpStatus } from '@nestjs/common';
+import { WhatsappWebhookQueryDto } from './dto/whatsapp-webhook-query.dto';
 import { WhatsappController } from './whatsapp.controller';
 
 describe('WhatsappController', () => {
@@ -94,6 +95,37 @@ describe('WhatsappController', () => {
 
     expect(whatsappService.verifyWebhookToken).not.toHaveBeenCalled();
     expect(res.sendStatus).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+  });
+
+  it('normalizes webhook verification query aliases', () => {
+    expect(
+      WhatsappWebhookQueryDto.zodSchema.parse({
+        'hub.mode': 'subscribe',
+        'hub.verify_token': 'verify',
+        'hub.challenge': '123456',
+        hub_mode: 'subscribe',
+        hub_verify_token: 'verify',
+        hub_challenge: '123456',
+      }),
+    ).toEqual({
+      'hub.mode': 'subscribe',
+      'hub.verify_token': 'verify',
+      'hub.challenge': '123456',
+    });
+  });
+
+  it('accepts webhook verification query aliases when canonical keys are missing', () => {
+    expect(
+      WhatsappWebhookQueryDto.zodSchema.parse({
+        hub_mode: 'subscribe',
+        hub_verify_token: 'verify',
+        hub_challenge: '123456',
+      }),
+    ).toEqual({
+      'hub.mode': 'subscribe',
+      'hub.verify_token': 'verify',
+      'hub.challenge': '123456',
+    });
   });
 
   it('verifyWebhook returns forbidden when token is invalid', () => {


### PR DESCRIPTION
## Summary
- Accept and normalize WhatsApp webhook verification query aliases (`hub_mode`, `hub_verify_token`, `hub_challenge`) to canonical Meta keys.
- Keep controller validation using the canonical `hub.*` values.
- Add coverage for canonical+alias and alias-only verification queries.

## Verification
- backend: `npm test -- --runTestsByPath src/whatsapp/whatsapp.controller.spec.ts`
- backend: `npm run type-check`
- backend: `npm run lint -- --fix=false`
- production hotfix: verified `https://rent.maese.com.ar/api/whatsapp/webhook` returns `200 text/plain` for canonical and alias query shapes.