### PR TITLE
Enhance WhatsApp messaging with template support and tests

### DIFF
--- a/backend/src/payments/payments.service.spec.ts
+++ b/backend/src/payments/payments.service.spec.ts
@@ -73,7 +73,10 @@ describe('PaymentsService', () => {
         { provide: CreditNotePdfService, useValue: { generate: jest.fn() } },
         {
           provide: WhatsappService,
-          useValue: { sendTextMessage: jest.fn() },
+          useValue: {
+            sendTextMessage: jest.fn(),
+            sendTemplateMessage: jest.fn(),
+          },
         },
       ],
     }).compile();
@@ -613,7 +616,7 @@ describe('PaymentsService', () => {
     const receiptPdfService = (service as any).receiptPdfService;
     receiptPdfService.generate.mockResolvedValue('https://pdf.local/r-new.pdf');
     const whatsappService = (service as any).whatsappService;
-    whatsappService.sendTextMessage.mockResolvedValue({ ok: true });
+    whatsappService.sendTemplateMessage.mockResolvedValue({ ok: true });
 
     const payment = {
       id: 'pay-1',
@@ -626,10 +629,20 @@ describe('PaymentsService', () => {
     const result = await (service as any).generateReceipt(payment);
 
     expect(receiptPdfService.generate).toHaveBeenCalled();
-    expect(whatsappService.sendTextMessage).toHaveBeenCalledWith(
+    expect(whatsappService.sendTemplateMessage).toHaveBeenCalledWith(
       '5491112345678',
-      expect.stringContaining('Tu recibo'),
-      'https://pdf.local/r-new.pdf',
+      'receipt_available',
+      'es',
+      ['REC-202502-0008'],
+      {
+        textFallback: expect.stringContaining('Tu recibo'),
+        pdfUrl: 'https://pdf.local/r-new.pdf',
+        context: {
+          companyId: 'company-1',
+          relatedEntityType: 'payment',
+          relatedEntityId: 'pay-1',
+        },
+      },
     );
     expect(result).toEqual(
       expect.objectContaining({
@@ -669,7 +682,7 @@ describe('PaymentsService', () => {
       'https://pdf.local/cn-1.pdf',
     );
     const whatsappService = (service as any).whatsappService;
-    whatsappService.sendTextMessage.mockResolvedValue({ ok: true });
+    whatsappService.sendTemplateMessage.mockResolvedValue({ ok: true });
 
     await (service as any).createCreditNotesForSettledLateFees(
       {

--- a/backend/src/payments/payments.service.ts
+++ b/backend/src/payments/payments.service.ts
@@ -276,10 +276,22 @@ export class PaymentsService {
         payment.tenant?.user?.phone ??
         payment.tenantAccount?.lease?.tenant?.user?.phone ??
         null;
+      const tenantLanguage =
+        payment.tenant?.user?.language ??
+        payment.tenantAccount?.lease?.tenant?.user?.language ??
+        'es';
       await this.sendTenantPdfWhatsapp(
         tenantPhone,
         `Tu recibo ${savedReceipt.receiptNumber} ya está disponible.`,
         savedReceipt.pdfUrl,
+        {
+          templateName: 'receipt_available',
+          templateLanguage: tenantLanguage,
+          templateParameters: [savedReceipt.receiptNumber],
+          companyId: payment.companyId,
+          relatedEntityType: 'payment',
+          relatedEntityId: payment.id,
+        },
       );
     } catch (error) {
       console.error('Failed to generate receipt PDF:', error);
@@ -620,6 +632,18 @@ export class PaymentsService {
             fullInvoice.lease?.tenant?.user?.phone ?? null,
             `Se emitió la nota de crédito ${savedNote.noteNumber} por ${savedNote.currencyCode} ${Number(savedNote.amount).toLocaleString('es-AR', { minimumFractionDigits: 2 })}.`,
             savedNote.pdfUrl,
+            {
+              templateName: 'credit_note_issued',
+              templateLanguage:
+                fullInvoice.lease?.tenant?.user?.language ?? 'es',
+              templateParameters: [
+                savedNote.noteNumber,
+                `${savedNote.currencyCode} ${Number(savedNote.amount).toLocaleString('es-AR', { minimumFractionDigits: 2 })}`,
+              ],
+              companyId: payment.companyId,
+              relatedEntityType: 'payment',
+              relatedEntityId: payment.id,
+            },
           );
         }
       } catch (error) {
@@ -670,12 +694,39 @@ export class PaymentsService {
     phone: string | null | undefined,
     text: string,
     pdfUrl?: string | null,
+    template?: {
+      templateName: string;
+      templateLanguage?: string;
+      templateParameters: string[];
+      companyId?: string;
+      relatedEntityType?: 'payment' | 'invoice';
+      relatedEntityId?: string;
+    },
   ): Promise<void> {
     if (!phone || !pdfUrl) {
       return;
     }
 
     try {
+      if (template) {
+        await this.whatsappService.sendTemplateMessage(
+          phone,
+          template.templateName,
+          template.templateLanguage ?? 'es',
+          template.templateParameters,
+          {
+            textFallback: text,
+            pdfUrl,
+            context: {
+              companyId: template.companyId,
+              relatedEntityType: template.relatedEntityType,
+              relatedEntityId: template.relatedEntityId,
+            },
+          },
+        );
+        return;
+      }
+
       await this.whatsappService.sendTextMessage(phone, text, pdfUrl);
     } catch (error) {
       console.error('Failed to send WhatsApp PDF notification:', error);

--- a/backend/src/properties/property-visits.service.spec.ts
+++ b/backend/src/properties/property-visits.service.spec.ts
@@ -24,7 +24,7 @@ describe('PropertyVisitsService', () => {
   let visitsRepository: MockRepository<PropertyVisit>;
   let notificationsRepository: MockRepository<PropertyVisitNotification>;
   let ownerActivitiesRepository: MockRepository<OwnerActivity>;
-  let whatsappService: { sendTextMessage: jest.Mock };
+  let whatsappService: { sendTemplateMessage: jest.Mock };
 
   type MockRepository<T extends Record<string, any> = any> = Partial<
     Record<keyof Repository<T>, jest.Mock>
@@ -39,7 +39,7 @@ describe('PropertyVisitsService', () => {
 
   beforeEach(async () => {
     whatsappService = {
-      sendTextMessage: jest
+      sendTemplateMessage: jest
         .fn()
         .mockResolvedValue({ messageId: 'wamid.test', raw: {} }),
     };
@@ -122,7 +122,22 @@ describe('PropertyVisitsService', () => {
     expect(result.notifications).toHaveLength(1);
     expect(notificationsRepository.save).toHaveBeenCalledTimes(2);
     expect(ownerActivitiesRepository.save).toHaveBeenCalledTimes(1);
-    expect(whatsappService.sendTextMessage).toHaveBeenCalledTimes(1);
+    expect(whatsappService.sendTemplateMessage).toHaveBeenCalledTimes(1);
+    expect(whatsappService.sendTemplateMessage).toHaveBeenCalledWith(
+      '+54 9 11 1234-5678',
+      'property_visit_registered',
+      'es',
+      ['Casa Linda', expect.any(String), 'Ana', 'Le gustó. Oferta ARS 1000'],
+      expect.objectContaining({
+        textFallback: expect.stringContaining('Se registró una visita'),
+        context: expect.objectContaining({
+          activityEntity: 'owner',
+          activityId: 'activity-1',
+          relatedEntityType: 'property_visit',
+          relatedEntityId: 'visit-1',
+        }),
+      }),
+    );
 
     const savedNotifications = notificationsRepository.save!.mock.calls[1][0];
     for (const notification of savedNotifications) {
@@ -217,7 +232,7 @@ describe('PropertyVisitsService', () => {
 
     expect(result.kind).toBe(PropertyVisitKind.MAINTENANCE);
     expect(result.interestedName).toBe('Revisar humedad');
-    expect(whatsappService.sendTextMessage).not.toHaveBeenCalled();
+    expect(whatsappService.sendTemplateMessage).not.toHaveBeenCalled();
     expect(notificationsRepository.save).not.toHaveBeenCalled();
     expect(ownerActivitiesRepository.create).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -413,7 +428,7 @@ describe('PropertyVisitsService', () => {
         { id: 'u1', role: 'agent', companyId: 'company-1' },
       );
 
-      expect(whatsappService.sendTextMessage).not.toHaveBeenCalled();
+      expect(whatsappService.sendTemplateMessage).not.toHaveBeenCalled();
       expect(notificationsRepository.save).not.toHaveBeenCalled();
       expect(result.notifications).toBeUndefined();
     });
@@ -429,7 +444,7 @@ describe('PropertyVisitsService', () => {
         ...d,
       }));
       notificationsRepository.save!.mockImplementation(async (d) => d);
-      whatsappService.sendTextMessage.mockRejectedValue(
+      whatsappService.sendTemplateMessage.mockRejectedValue(
         new Error('WhatsApp API error'),
       );
 

--- a/backend/src/properties/property-visits.service.ts
+++ b/backend/src/properties/property-visits.service.ts
@@ -31,6 +31,14 @@ interface VisitUserContext {
   companyId?: string;
 }
 
+interface VisitWhatsappContext {
+  companyId: string;
+  relatedEntityId: string;
+  activityId?: string;
+  templateLanguage?: string;
+  templateParameters: string[];
+}
+
 @Injectable()
 export class PropertyVisitsService {
   constructor(
@@ -66,14 +74,27 @@ export class PropertyVisitsService {
       user,
     );
 
-    await this.createOwnerVisitActivity(property, savedVisit, user);
+    const ownerActivity = await this.createOwnerVisitActivity(
+      property,
+      savedVisit,
+      user,
+    );
 
     const notifications = this.buildNotifications(property, savedVisit);
     if (notifications.length > 0) {
       const savedNotifications =
         await this.notificationsRepository.save(notifications);
       savedVisit.notifications = savedNotifications;
-      await this.dispatchNotifications(savedNotifications);
+      await this.dispatchNotifications(savedNotifications, {
+        companyId: property.companyId,
+        relatedEntityId: savedVisit.id,
+        activityId: ownerActivity?.id,
+        templateLanguage: property.owner?.user?.language ?? 'es',
+        templateParameters: this.buildVisitTemplateParameters(
+          property,
+          savedVisit,
+        ),
+      });
     }
 
     return savedVisit;
@@ -256,15 +277,15 @@ export class PropertyVisitsService {
     property: Property,
     visit: PropertyVisit,
     user: VisitUserContext,
-  ): Promise<void> {
+  ): Promise<OwnerActivity | null> {
     if (!property.ownerId) {
-      return;
+      return null;
     }
 
     const interested =
       visit.interestedName?.trim() || visit.interestedProfileId || 'Visita';
 
-    await this.ownerActivitiesRepository.save(
+    return this.ownerActivitiesRepository.save(
       this.ownerActivitiesRepository.create({
         companyId: property.companyId,
         ownerId: property.ownerId,
@@ -337,12 +358,34 @@ export class PropertyVisitsService {
     }).format(value);
   }
 
+  private buildVisitTemplateParameters(
+    property: Property,
+    visit: PropertyVisit,
+  ): string[] {
+    const interested =
+      visit.interestedName?.trim() || visit.interestedProfileId || 'N/D';
+    const detailParts = [
+      visit.comments?.trim() || 'Sin comentarios',
+      visit.hasOffer && visit.offerAmount !== undefined
+        ? `Oferta ${visit.offerCurrency ?? 'ARS'} ${visit.offerAmount}`
+        : null,
+    ].filter(Boolean);
+
+    return [
+      property.name,
+      this.formatWhatsappDate(visit.visitedAt),
+      interested,
+      detailParts.join('. '),
+    ];
+  }
+
   private async dispatchNotifications(
     notifications: PropertyVisitNotification[],
+    context?: VisitWhatsappContext,
   ): Promise<void> {
     for (const notification of notifications) {
       try {
-        await this.sendNotification(notification);
+        await this.sendNotification(notification, context);
         notification.status = VisitNotificationStatus.SENT;
         notification.sentAt = new Date();
         notification.error = null;
@@ -358,11 +401,26 @@ export class PropertyVisitsService {
 
   private async sendNotification(
     notification: PropertyVisitNotification,
+    context?: VisitWhatsappContext,
   ): Promise<void> {
     if (notification.channel === VisitNotificationChannel.WHATSAPP) {
-      await this.whatsappService.sendTextMessage(
+      await this.whatsappService.sendTemplateMessage(
         notification.recipient,
-        notification.message,
+        'property_visit_registered',
+        context?.templateLanguage ?? 'es',
+        context?.templateParameters ?? [],
+        {
+          textFallback: notification.message,
+          context: context
+            ? {
+                companyId: context.companyId,
+                relatedEntityType: 'property_visit',
+                relatedEntityId: context.relatedEntityId,
+                activityEntity: context.activityId ? 'owner' : undefined,
+                activityId: context.activityId,
+              }
+            : undefined,
+        },
       );
     }
   }

--- a/backend/src/whatsapp/dto/send-whatsapp-message.dto.ts
+++ b/backend/src/whatsapp/dto/send-whatsapp-message.dto.ts
@@ -1,6 +1,9 @@
 import {
+  IsArray,
+  IsIn,
   IsOptional,
   IsString,
+  IsUUID,
   Matches,
   MaxLength,
   MinLength,
@@ -20,6 +23,32 @@ const sendWhatsappMessageZodSchema = z
       .regex(/^db:\/\/document\/[0-9a-fA-F-]+$/)
       .max(200)
       .optional(),
+    templateName: z
+      .string()
+      .min(1)
+      .max(120)
+      .regex(/^[a-z0-9_]+$/)
+      .optional(),
+    templateLanguage: z
+      .string()
+      .regex(/^[a-z]{2}(_[A-Z]{2})?$/)
+      .optional(),
+    templateParameters: z.array(z.string().max(1024)).max(20).optional(),
+    activityEntity: z.enum(['tenant', 'owner', 'interested']).optional(),
+    activityId: z.string().uuid().optional(),
+    relatedEntityType: z
+      .enum([
+        'tenant',
+        'owner',
+        'interested',
+        'property_visit',
+        'invoice',
+        'payment',
+        'lease',
+      ])
+      .optional(),
+    relatedEntityId: z.string().uuid().optional(),
+    companyId: z.string().uuid().optional(),
   })
   .strict();
 
@@ -41,4 +70,55 @@ export class SendWhatsappMessageDto {
   @Matches(/^db:\/\/document\/[0-9a-fA-F-]+$/)
   @MaxLength(200)
   pdfUrl?: string;
+
+  @IsOptional()
+  @IsString()
+  @Matches(/^[a-z0-9_]+$/)
+  @MaxLength(120)
+  templateName?: string;
+
+  @IsOptional()
+  @IsString()
+  @Matches(/^[a-z]{2}(_[A-Z]{2})?$/)
+  templateLanguage?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  templateParameters?: string[];
+
+  @IsOptional()
+  @IsIn(['tenant', 'owner', 'interested'])
+  activityEntity?: 'tenant' | 'owner' | 'interested';
+
+  @IsOptional()
+  @IsUUID()
+  activityId?: string;
+
+  @IsOptional()
+  @IsIn([
+    'tenant',
+    'owner',
+    'interested',
+    'property_visit',
+    'invoice',
+    'payment',
+    'lease',
+  ])
+  relatedEntityType?:
+    | 'tenant'
+    | 'owner'
+    | 'interested'
+    | 'property_visit'
+    | 'invoice'
+    | 'payment'
+    | 'lease';
+
+  @IsOptional()
+  @IsUUID()
+  relatedEntityId?: string;
+
+  @IsOptional()
+  @IsUUID()
+  companyId?: string;
 }

--- a/backend/src/whatsapp/dto/whatsapp-webhook-query.dto.ts
+++ b/backend/src/whatsapp/dto/whatsapp-webhook-query.dto.ts
@@ -3,11 +3,39 @@ import { z } from 'zod';
 
 const whatsappWebhookQueryZodSchema = z
   .object({
-    'hub.mode': z.string().min(1),
-    'hub.verify_token': z.string().min(1),
-    'hub.challenge': z.string().min(1),
+    'hub.mode': z.string().min(1).optional(),
+    'hub.verify_token': z.string().min(1).optional(),
+    'hub.challenge': z.string().min(1).optional(),
+    hub_mode: z.string().min(1).optional(),
+    hub_verify_token: z.string().min(1).optional(),
+    hub_challenge: z.string().min(1).optional(),
   })
-  .strict();
+  .strict()
+  .transform((query, ctx) => {
+    const mode = query['hub.mode'] ?? query.hub_mode;
+    const verifyToken = query['hub.verify_token'] ?? query.hub_verify_token;
+    const challenge = query['hub.challenge'] ?? query.hub_challenge;
+
+    for (const [key, value] of [
+      ['hub.mode', mode],
+      ['hub.verify_token', verifyToken],
+      ['hub.challenge', challenge],
+    ] as const) {
+      if (!value) {
+        ctx.addIssue({
+          code: 'custom',
+          path: [key],
+          message: 'Required',
+        });
+      }
+    }
+
+    return {
+      'hub.mode': mode,
+      'hub.verify_token': verifyToken,
+      'hub.challenge': challenge,
+    };
+  });
 
 export class WhatsappWebhookQueryDto {
   static readonly zodSchema = whatsappWebhookQueryZodSchema;

--- a/backend/src/whatsapp/whatsapp.controller.spec.ts
+++ b/backend/src/whatsapp/whatsapp.controller.spec.ts
@@ -5,6 +5,7 @@ import { WhatsappController } from './whatsapp.controller';
 describe('WhatsappController', () => {
   const whatsappService = {
     sendTextMessage: jest.fn(),
+    sendTemplateMessage: jest.fn(),
     assertBatchToken: jest.fn(),
     verifyWebhookToken: jest.fn(),
     handleIncomingWebhook: jest.fn(),
@@ -36,6 +37,13 @@ describe('WhatsappController', () => {
       '54911',
       'hola',
       undefined,
+      {
+        activityEntity: undefined,
+        activityId: undefined,
+        companyId: undefined,
+        relatedEntityId: undefined,
+        relatedEntityType: undefined,
+      },
     );
   });
 
@@ -53,6 +61,47 @@ describe('WhatsappController', () => {
       '54911',
       'hola',
       'db://document/1',
+      {
+        activityEntity: undefined,
+        activityId: undefined,
+        companyId: undefined,
+        relatedEntityId: undefined,
+        relatedEntityType: undefined,
+      },
+    );
+  });
+
+  it('sendMessage delegates template payloads to whatsapp service', async () => {
+    whatsappService.sendTemplateMessage.mockResolvedValue({ messageId: 'tpl' });
+    const dto = {
+      to: '54911',
+      text: 'fallback',
+      templateName: 'invoice_available',
+      templateLanguage: 'es_AR',
+      templateParameters: ['Juan', 'F-1', '2026-07-15', 'ARS 1000,00'],
+      activityEntity: 'tenant',
+      activityId: '123e4567-e89b-12d3-a456-426614174000',
+    } as any;
+
+    await expect(controller.sendMessage(dto)).resolves.toEqual({
+      messageId: 'tpl',
+    });
+    expect(whatsappService.sendTemplateMessage).toHaveBeenCalledWith(
+      '54911',
+      'invoice_available',
+      'es_AR',
+      ['Juan', 'F-1', '2026-07-15', 'ARS 1000,00'],
+      {
+        textFallback: 'fallback',
+        pdfUrl: undefined,
+        context: {
+          activityEntity: 'tenant',
+          activityId: '123e4567-e89b-12d3-a456-426614174000',
+          companyId: undefined,
+          relatedEntityId: undefined,
+          relatedEntityType: undefined,
+        },
+      },
     );
   });
 
@@ -148,9 +197,11 @@ describe('WhatsappController', () => {
     expect(res.sendStatus).toHaveBeenCalledWith(HttpStatus.FORBIDDEN);
   });
 
-  it('receiveWebhook delegates and returns ack', () => {
+  it('receiveWebhook delegates and returns ack', async () => {
     const payload = { entry: [] } as any;
-    expect(controller.receiveWebhook(payload)).toEqual({ received: true });
+    await expect(controller.receiveWebhook(payload)).resolves.toEqual({
+      received: true,
+    });
     expect(whatsappService.handleIncomingWebhook).toHaveBeenCalledWith(payload);
   });
 

--- a/backend/src/whatsapp/whatsapp.controller.spec.ts
+++ b/backend/src/whatsapp/whatsapp.controller.spec.ts
@@ -1,4 +1,5 @@
 import { ForbiddenException, HttpStatus } from '@nestjs/common';
+import { WhatsappWebhookQueryDto } from './dto/whatsapp-webhook-query.dto';
 import { WhatsappController } from './whatsapp.controller';
 
 describe('WhatsappController', () => {
@@ -94,6 +95,37 @@ describe('WhatsappController', () => {
 
     expect(whatsappService.verifyWebhookToken).not.toHaveBeenCalled();
     expect(res.sendStatus).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+  });
+
+  it('normalizes webhook verification query aliases', () => {
+    expect(
+      WhatsappWebhookQueryDto.zodSchema.parse({
+        'hub.mode': 'subscribe',
+        'hub.verify_token': 'verify',
+        'hub.challenge': '123456',
+        hub_mode: 'subscribe',
+        hub_verify_token: 'verify',
+        hub_challenge: '123456',
+      }),
+    ).toEqual({
+      'hub.mode': 'subscribe',
+      'hub.verify_token': 'verify',
+      'hub.challenge': '123456',
+    });
+  });
+
+  it('accepts webhook verification query aliases when canonical keys are missing', () => {
+    expect(
+      WhatsappWebhookQueryDto.zodSchema.parse({
+        hub_mode: 'subscribe',
+        hub_verify_token: 'verify',
+        hub_challenge: '123456',
+      }),
+    ).toEqual({
+      'hub.mode': 'subscribe',
+      'hub.verify_token': 'verify',
+      'hub.challenge': '123456',
+    });
   });
 
   it('verifyWebhook returns forbidden when token is invalid', () => {

--- a/backend/src/whatsapp/whatsapp.controller.ts
+++ b/backend/src/whatsapp/whatsapp.controller.ts
@@ -29,7 +29,7 @@ export class WhatsappController {
 
   @Post('messages')
   async sendMessage(@Body() dto: SendWhatsappMessageDto) {
-    return this.whatsappService.sendTextMessage(dto.to, dto.text, dto.pdfUrl);
+    return this.sendMessageFromDto(dto);
   }
 
   @Public()
@@ -39,7 +39,7 @@ export class WhatsappController {
     @Headers('x-batch-whatsapp-token') token?: string,
   ) {
     this.whatsappService.assertBatchToken(token);
-    return this.whatsappService.sendTextMessage(dto.to, dto.text, dto.pdfUrl);
+    return this.sendMessageFromDto(dto);
   }
 
   @Public()
@@ -69,8 +69,8 @@ export class WhatsappController {
   @Public()
   @Post('webhook')
   @HttpCode(HttpStatus.OK)
-  receiveWebhook(@Body() payload: WhatsappWebhookPayloadDto) {
-    this.whatsappService.handleIncomingWebhook(payload);
+  async receiveWebhook(@Body() payload: WhatsappWebhookPayloadDto) {
+    await this.whatsappService.handleIncomingWebhook(payload);
     return { received: true };
   }
 
@@ -97,5 +97,36 @@ export class WhatsappController {
     });
 
     return res.send(buffer);
+  }
+
+  private sendMessageFromDto(dto: SendWhatsappMessageDto) {
+    const context = {
+      companyId: dto.companyId,
+      relatedEntityType: dto.relatedEntityType,
+      relatedEntityId: dto.relatedEntityId,
+      activityEntity: dto.activityEntity,
+      activityId: dto.activityId,
+    };
+
+    if (dto.templateName) {
+      return this.whatsappService.sendTemplateMessage(
+        dto.to,
+        dto.templateName,
+        dto.templateLanguage ?? 'es',
+        dto.templateParameters ?? [],
+        {
+          textFallback: dto.text,
+          pdfUrl: dto.pdfUrl,
+          context,
+        },
+      );
+    }
+
+    return this.whatsappService.sendTextMessage(
+      dto.to,
+      dto.text,
+      dto.pdfUrl,
+      context,
+    );
   }
 }

--- a/backend/src/whatsapp/whatsapp.service.spec.ts
+++ b/backend/src/whatsapp/whatsapp.service.spec.ts
@@ -117,6 +117,61 @@ describe('WhatsappService', () => {
     (Date.now as jest.Mock).mockRestore();
   });
 
+  it('sendTemplateMessage sends template payload and optional document', async () => {
+    const service = buildService();
+    jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ messages: [{ id: 'wamid-template' }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ messages: [{ id: 'wamid-document' }] }),
+      });
+
+    const result = await service.sendTemplateMessage(
+      '+5491112345678',
+      'invoice_available',
+      'es',
+      ['Juan', 'F-1', '2026-07-15', 'ARS 1000,00'],
+      {
+        textFallback: 'Factura disponible',
+        pdfUrl: 'db://document/123e4567-e89b-12d3-a456-426614174000',
+      },
+    );
+
+    const templatePayload = JSON.parse(
+      fetchMock.mock.calls[0][1].body as string,
+    );
+    expect(templatePayload.type).toBe('template');
+    expect(templatePayload.template).toEqual({
+      name: 'invoice_available',
+      language: { code: 'es_AR' },
+      components: [
+        {
+          type: 'body',
+          parameters: [
+            { type: 'text', text: 'Juan' },
+            { type: 'text', text: 'F-1' },
+            { type: 'text', text: '2026-07-15' },
+            { type: 'text', text: 'ARS 1000,00' },
+          ],
+        },
+      ],
+    });
+    const documentPayload = JSON.parse(
+      fetchMock.mock.calls[1][1].body as string,
+    );
+    expect(documentPayload.type).toBe('document');
+    expect(result).toEqual({
+      messageId: 'wamid-template',
+      raw: { messages: [{ id: 'wamid-template' }] },
+      documentMessageId: 'wamid-document',
+    });
+    (Date.now as jest.Mock).mockRestore();
+  });
+
   it('sendTextMessage throws for invalid db url or missing doc secret', async () => {
     const service = buildService();
     await expect(

--- a/backend/src/whatsapp/whatsapp.service.spec.ts
+++ b/backend/src/whatsapp/whatsapp.service.spec.ts
@@ -10,7 +10,7 @@ describe('WhatsappService', () => {
   const originalEnv = { ...process.env };
   const fetchMock = jest.fn();
 
-  const buildService = (env?: Record<string, string>) => {
+  const buildService = (env?: Record<string, string>, dataSource?: any) => {
     process.env = {
       ...originalEnv,
       WHATSAPP_ENABLED: 'true',
@@ -23,7 +23,30 @@ describe('WhatsappService', () => {
       BATCH_WHATSAPP_INTERNAL_TOKEN: 'batch-token',
       ...env,
     };
-    return new WhatsappService();
+    return new WhatsappService(dataSource);
+  };
+
+  const buildDataSource = (
+    queryMock = jest.fn().mockResolvedValue([]),
+    type = 'postgres',
+  ) => ({
+    options: { type },
+    query: queryMock,
+  });
+
+  const mockSuccessfulSend = (messageId = 'wamid-1') => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ messages: [{ id: messageId }] }),
+    });
+  };
+
+  const buildServiceWithExactEnv = (
+    env: Record<string, string>,
+    dataSource?: any,
+  ) => {
+    process.env = { ...env };
+    return new WhatsappService(dataSource);
   };
 
   beforeEach(() => {
@@ -61,10 +84,7 @@ describe('WhatsappService', () => {
 
   it('sendTextMessage sends text payload and returns message id', async () => {
     const service = buildService();
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({ messages: [{ id: 'wamid-1' }] }),
-    });
+    mockSuccessfulSend();
 
     const result = await service.sendTextMessage(
       '+54 9 11 1234-5678',
@@ -115,6 +135,30 @@ describe('WhatsappService', () => {
       'https://frontend.example.com/whatsapp/documents/123e4567-e89b-12d3-a456-426614174000?token=',
     );
     (Date.now as jest.Mock).mockRestore();
+  });
+
+  it('uses environment defaults for API base, enabled flag and document URL settings', async () => {
+    const service = buildServiceWithExactEnv({
+      PORT: '3456',
+      WHATSAPP_PHONE_NUMBER_ID: 'phone-1',
+      WHATSAPP_ACCESS_TOKEN: 'token-1',
+      WHATSAPP_DOCUMENT_LINK_SECRET: 'doc-secret',
+    });
+    mockSuccessfulSend('wamid-default-env');
+
+    await service.sendTextMessage(
+      '+5491112345678',
+      'documento',
+      'db://document/123e4567-e89b-12d3-a456-426614174000',
+    );
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://graph.facebook.com/v22.0/phone-1/messages',
+    );
+    const payload = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(payload.document.link).toContain(
+      'http://localhost:3456/whatsapp/documents/123e4567-e89b-12d3-a456-426614174000?token=',
+    );
   });
 
   it('sendTemplateMessage sends template payload and optional document', async () => {
@@ -172,6 +216,97 @@ describe('WhatsappService', () => {
     (Date.now as jest.Mock).mockRestore();
   });
 
+  it('sendTemplateMessage sends templates without body params or document', async () => {
+    const service = buildService();
+    mockSuccessfulSend('wamid-no-params');
+
+    const result = await service.sendTemplateMessage(
+      '+5491112345678',
+      'receipt_available',
+      'pt',
+      [],
+    );
+
+    const payload = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(payload.template).toEqual({
+      name: 'receipt_available',
+      language: { code: 'pt_BR' },
+    });
+    expect(result).toEqual({
+      messageId: 'wamid-no-params',
+      raw: { messages: [{ id: 'wamid-no-params' }] },
+    });
+  });
+
+  it('sendTemplateMessage uses default document caption and handles null parameters', async () => {
+    const service = buildService();
+    jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ messages: [{ id: 'wamid-template' }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ messages: [{ id: 'wamid-document' }] }),
+      });
+
+    await service.sendTemplateMessage(
+      '+5491112345678',
+      'receipt_available',
+      'en_US',
+      [null as any],
+      {
+        pdfUrl: 'db://document/123e4567-e89b-12d3-a456-426614174000',
+      },
+    );
+
+    const templatePayload = JSON.parse(
+      fetchMock.mock.calls[0][1].body as string,
+    );
+    expect(templatePayload.template.components[0].parameters).toEqual([
+      { type: 'text', text: '' },
+    ]);
+    const documentPayload = JSON.parse(
+      fetchMock.mock.calls[1][1].body as string,
+    );
+    expect(documentPayload.document.caption).toBe('Documento disponible.');
+    (Date.now as jest.Mock).mockRestore();
+  });
+
+  it('sendTemplateMessage validates disabled config, phone and template name', async () => {
+    await expect(
+      buildService({ WHATSAPP_ENABLED: 'false' }).sendTemplateMessage(
+        '+5491112345678',
+        'invoice_available',
+        'es',
+        [],
+      ),
+    ).rejects.toBeInstanceOf(ServiceUnavailableException);
+
+    await expect(
+      buildService({ WHATSAPP_PHONE_NUMBER_ID: '' }).sendTemplateMessage(
+        '+5491112345678',
+        'invoice_available',
+        'es',
+        [],
+      ),
+    ).rejects.toBeInstanceOf(ServiceUnavailableException);
+
+    await expect(
+      buildService().sendTemplateMessage('abc', 'invoice_available', 'es', []),
+    ).rejects.toBeInstanceOf(BadGatewayException);
+
+    await expect(
+      buildService().sendTemplateMessage(
+        '+5491112345678',
+        'bad-template!',
+        'es',
+        [],
+      ),
+    ).rejects.toBeInstanceOf(BadGatewayException);
+  });
+
   it('sendTextMessage throws for invalid db url or missing doc secret', async () => {
     const service = buildService();
     await expect(
@@ -213,10 +348,17 @@ describe('WhatsappService', () => {
     ).rejects.toBeInstanceOf(BadGatewayException);
   });
 
-  it('verifies webhook and document tokens', () => {
+  it('verifies webhook, languages and document tokens', () => {
     const service = buildService();
     expect(service.verifyWebhookToken('verify-1')).toBe(true);
     expect(service.verifyWebhookToken('wrong')).toBe(false);
+    expect(service.resolveLanguageCode('en')).toBe('en_US');
+    expect(service.resolveLanguageCode('en_US')).toBe('en_US');
+    expect(service.resolveLanguageCode('es_AR')).toBe('es_AR');
+    expect(service.resolveLanguageCode('pt')).toBe('pt_BR');
+    expect(service.resolveLanguageCode('pt_BR')).toBe('pt_BR');
+    expect(service.resolveLanguageCode('unknown')).toBe('es_AR');
+    expect(service.resolveLanguageCode()).toBe('es_AR');
 
     const documentId = '123e4567-e89b-12d3-a456-426614174000';
     const exp = Math.floor(Date.now() / 1000) + 600;
@@ -247,18 +389,18 @@ describe('WhatsappService', () => {
     );
   });
 
-  it('handleIncomingWebhook logs both no-message and message cases', () => {
+  it('handleIncomingWebhook logs both no-message and message cases', async () => {
     const service = buildService();
     const logger = (service as any).logger;
     const debugSpy = jest.spyOn(logger, 'debug').mockImplementation();
     const logSpy = jest.spyOn(logger, 'log').mockImplementation();
 
-    service.handleIncomingWebhook({});
+    await service.handleIncomingWebhook({});
     expect(debugSpy).toHaveBeenCalledWith(
       'WhatsApp webhook received without messages',
     );
 
-    service.handleIncomingWebhook({
+    await service.handleIncomingWebhook({
       entry: [
         {
           changes: [
@@ -272,5 +414,349 @@ describe('WhatsappService', () => {
     expect(logSpy).toHaveBeenCalledWith(
       'WhatsApp webhook message from 54911: hola',
     );
+  });
+
+  it('handleIncomingWebhook logs non-text messages and tolerates malformed changes', async () => {
+    const service = buildService();
+    const logger = (service as any).logger;
+    const logSpy = jest.spyOn(logger, 'log').mockImplementation();
+
+    await service.handleIncomingWebhook({
+      entry: [
+        {
+          changes: [
+            {},
+            {
+              value: { messages: [{}] },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(logSpy).toHaveBeenCalledWith(
+      'WhatsApp webhook message from unknown: [non-text-message]',
+    );
+  });
+
+  it('creates tracking table on postgres bootstrap only', async () => {
+    const postgresQuery = jest.fn().mockResolvedValue([]);
+    const postgresService = buildService(
+      undefined,
+      buildDataSource(postgresQuery),
+    );
+    await postgresService.onApplicationBootstrap();
+    expect(postgresQuery).toHaveBeenCalledTimes(3);
+    expect(postgresQuery.mock.calls[0][0]).toContain(
+      'CREATE TABLE IF NOT EXISTS whatsapp_messages',
+    );
+    expect(postgresQuery.mock.calls[1][0]).toContain(
+      'idx_whatsapp_messages_activity',
+    );
+    expect(postgresQuery.mock.calls[2][0]).toContain(
+      'idx_whatsapp_messages_related',
+    );
+
+    const sqliteQuery = jest.fn();
+    const sqliteService = buildService(
+      undefined,
+      buildDataSource(sqliteQuery, 'sqlite'),
+    );
+    await sqliteService.onApplicationBootstrap();
+    expect(sqliteQuery).not.toHaveBeenCalled();
+
+    const serviceWithoutDataSource = buildService();
+    await expect(
+      serviceWithoutDataSource.onApplicationBootstrap(),
+    ).resolves.toBe(undefined);
+  });
+
+  it('records outbound sent messages and updates linked activity metadata', async () => {
+    const query = jest.fn().mockResolvedValue([]);
+    const service = buildService(undefined, buildDataSource(query));
+    mockSuccessfulSend('wamid-tracked');
+
+    await service.sendTextMessage('+5491112345678', 'hola', undefined, {
+      companyId: '123e4567-e89b-12d3-a456-426614174000',
+      relatedEntityType: 'tenant',
+      relatedEntityId: '123e4567-e89b-12d3-a456-426614174001',
+      activityEntity: 'tenant',
+      activityId: '123e4567-e89b-12d3-a456-426614174002',
+    });
+
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(query.mock.calls[0][0]).toContain('INSERT INTO whatsapp_messages');
+    expect(query.mock.calls[0][1]).toEqual(
+      expect.arrayContaining([
+        'wamid-tracked',
+        '5491112345678',
+        'text',
+        'hola',
+        'sent',
+        '123e4567-e89b-12d3-a456-426614174000',
+        'tenant',
+        '123e4567-e89b-12d3-a456-426614174001',
+        'tenant',
+        '123e4567-e89b-12d3-a456-426614174002',
+      ]),
+    );
+    expect(query.mock.calls[1][0]).toContain('UPDATE tenant_activities');
+    expect(query.mock.calls[1][1][0]).toBe(
+      '123e4567-e89b-12d3-a456-426614174002',
+    );
+    expect(JSON.parse(query.mock.calls[1][1][1])).toEqual(
+      expect.objectContaining({
+        messageId: 'wamid-tracked',
+        status: 'sent',
+      }),
+    );
+  });
+
+  it('records sent messages without a provider message id or raw body', async () => {
+    const query = jest.fn().mockResolvedValue([]);
+    const service = buildService(undefined, buildDataSource(query));
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+
+    const result = await service.sendTextMessage('+5491112345678', 'hola');
+
+    expect(result).toEqual({ messageId: null, raw: {} });
+    expect(query.mock.calls[0][1]).toEqual(
+      expect.arrayContaining([null, '5491112345678', 'text', 'sent', '{}']),
+    );
+  });
+
+  it('records outbound failures and keeps provider errors', async () => {
+    const query = jest.fn().mockResolvedValue([]);
+    const service = buildService(undefined, buildDataSource(query));
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: { message: 'template paused' } }),
+    });
+
+    await expect(
+      service.sendTemplateMessage('+5491112345678', 'invoice_available', 'es', [
+        'Juan',
+      ]),
+    ).rejects.toBeInstanceOf(BadGatewayException);
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0][0]).toContain('INSERT INTO whatsapp_messages');
+    expect(query.mock.calls[0][1]).toEqual(
+      expect.arrayContaining([
+        null,
+        '5491112345678',
+        'template',
+        'invoice_available',
+        'es_AR',
+        'failed',
+        'template paused',
+      ]),
+    );
+  });
+
+  it('does not fail sends when tracking persistence fails', async () => {
+    const query = jest.fn().mockRejectedValue(new Error('db down'));
+    const service = buildService(undefined, buildDataSource(query));
+    const logger = (service as any).logger;
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation();
+    mockSuccessfulSend('wamid-db-error');
+
+    await expect(
+      service.sendTextMessage('+5491112345678', 'hola'),
+    ).resolves.toEqual({
+      messageId: 'wamid-db-error',
+      raw: { messages: [{ id: 'wamid-db-error' }] },
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to record WhatsApp message tracking data',
+      { error: 'db down' },
+    );
+  });
+
+  it('logs non-Error tracking persistence failures', async () => {
+    const query = jest.fn().mockRejectedValue('db string error');
+    const service = buildService(undefined, buildDataSource(query));
+    const logger = (service as any).logger;
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation();
+    mockSuccessfulSend('wamid-string-error');
+
+    await service.sendTextMessage('+5491112345678', 'hola');
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to record WhatsApp message tracking data',
+      { error: 'db string error' },
+    );
+  });
+
+  it('updates message status from webhook and patches activity metadata', async () => {
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          activity_entity: 'interested',
+          activity_id: '123e4567-e89b-12d3-a456-426614174099',
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    const service = buildService(undefined, buildDataSource(query));
+
+    await service.handleIncomingWebhook({
+      entry: [
+        {
+          changes: [
+            {
+              value: {
+                statuses: [
+                  {
+                    id: 'wamid-status',
+                    status: 'delivered',
+                    timestamp: '1700000000',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(query.mock.calls[0][0]).toContain('UPDATE whatsapp_messages');
+    expect(query.mock.calls[0][1][0]).toBe('wamid-status');
+    expect(query.mock.calls[0][1][1]).toBe('delivered');
+    expect(query.mock.calls[0][1][3]).toEqual(new Date(1_700_000_000_000));
+    expect(query.mock.calls[1][0]).toContain('UPDATE interested_activities');
+    expect(JSON.parse(query.mock.calls[1][1][1])).toEqual(
+      expect.objectContaining({
+        messageId: 'wamid-status',
+        status: 'delivered',
+        deliveredAt: '2023-11-14T22:13:20.000Z',
+      }),
+    );
+  });
+
+  it('updates read and sent statuses with activity metadata timestamps', async () => {
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          activity_entity: 'owner',
+          activity_id: '123e4567-e89b-12d3-a456-426614174088',
+        },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          activity_entity: 'tenant',
+          activity_id: '123e4567-e89b-12d3-a456-426614174077',
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    const service = buildService(undefined, buildDataSource(query));
+
+    await service.handleIncomingWebhook({
+      entry: [
+        {
+          changes: [
+            {
+              value: {
+                statuses: [
+                  {
+                    id: 'wamid-read',
+                    status: 'read',
+                    timestamp: '1700000001',
+                  },
+                  {
+                    id: 'wamid-sent',
+                    status: 'sent',
+                    timestamp: '1700000002',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(query.mock.calls[0][1][1]).toBe('read');
+    expect(query.mock.calls[0][1][4]).toEqual(new Date(1_700_000_001_000));
+    expect(JSON.parse(query.mock.calls[1][1][1])).toEqual(
+      expect.objectContaining({
+        status: 'read',
+        readAt: '2023-11-14T22:13:21.000Z',
+      }),
+    );
+    expect(query.mock.calls[2][1][1]).toBe('sent');
+    expect(query.mock.calls[2][1][2]).toEqual(new Date(1_700_000_002_000));
+    expect(JSON.parse(query.mock.calls[3][1][1])).toEqual(
+      expect.objectContaining({
+        status: 'sent',
+        sentAt: '2023-11-14T22:13:22.000Z',
+      }),
+    );
+  });
+
+  it('handles failed status payloads, invalid statuses and missing timestamps', async () => {
+    const query = jest.fn().mockResolvedValue([]);
+    const service = buildService(undefined, buildDataSource(query));
+
+    await service.handleIncomingWebhook({
+      entry: [
+        {
+          changes: [
+            {
+              value: {
+                statuses: [
+                  { id: 'ignored', status: 'unknown' },
+                  {
+                    id: 'wamid-failed',
+                    status: 'failed',
+                    errors: [{ message: 'user unavailable' }, {}],
+                  },
+                  { status: 'read' },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0][1][0]).toBe('wamid-failed');
+    expect(query.mock.calls[0][1][1]).toBe('failed');
+    expect(query.mock.calls[0][1][5]).toBeInstanceOf(Date);
+    expect(query.mock.calls[0][1][6]).toBe('user unavailable');
+  });
+
+  it('ignores status and metadata updates when no datasource is configured', async () => {
+    const service = buildService();
+
+    await expect(
+      service.handleIncomingWebhook({
+        entry: [
+          {
+            changes: [
+              {
+                value: {
+                  statuses: [{ id: 'wamid-no-db', status: 'read' }],
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      (service as any).updateActivityMetadata('tenant', 'activity-1', {
+        status: 'read',
+      }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/backend/src/whatsapp/whatsapp.service.ts
+++ b/backend/src/whatsapp/whatsapp.service.ts
@@ -264,35 +264,52 @@ export class WhatsappService implements OnApplicationBootstrap {
   }
 
   async handleIncomingWebhook(payload: unknown): Promise<void> {
-    const entries = Array.isArray((payload as any)?.entry)
-      ? (payload as any).entry
-      : [];
     let sawMessage = false;
     let sawStatus = false;
 
-    for (const entry of entries) {
-      const changes = Array.isArray(entry?.changes) ? entry.changes : [];
-      for (const item of changes) {
+    for (const entry of this.getWebhookEntries(payload)) {
+      for (const item of this.asArray(entry?.changes)) {
         const value = item?.value;
-        const statuses = Array.isArray(value?.statuses) ? value.statuses : [];
-        for (const status of statuses) {
-          sawStatus = true;
-          await this.updateMessageStatus(status);
-        }
-
-        const messages = Array.isArray(value?.messages) ? value.messages : [];
-        for (const message of messages) {
-          sawMessage = true;
-          const from = message.from ?? 'unknown';
-          const text = message.text?.body ?? '[non-text-message]';
-          this.logger.log(`WhatsApp webhook message from ${from}: ${text}`);
-        }
+        sawStatus =
+          (await this.handleWebhookStatuses(value?.statuses)) || sawStatus;
+        sawMessage = this.logWebhookMessages(value?.messages) || sawMessage;
       }
     }
 
     if (!sawMessage && !sawStatus) {
       this.logger.debug('WhatsApp webhook received without messages');
     }
+  }
+
+  private getWebhookEntries(payload: unknown): any[] {
+    return this.asArray((payload as any)?.entry);
+  }
+
+  private asArray(value: unknown): any[] {
+    return Array.isArray(value) ? value : [];
+  }
+
+  private async handleWebhookStatuses(statuses: unknown): Promise<boolean> {
+    const items = this.asArray(statuses);
+
+    for (const status of items) {
+      await this.updateMessageStatus(status);
+    }
+
+    return items.length > 0;
+  }
+
+  private logWebhookMessages(messages: unknown): boolean {
+    const items = this.asArray(messages);
+
+    for (const item of items) {
+      const message = item as any;
+      const from = message?.from ?? 'unknown';
+      const text = message?.text?.body ?? '[non-text-message]';
+      this.logger.log(`WhatsApp webhook message from ${from}: ${text}`);
+    }
+
+    return items.length > 0;
   }
 
   resolveLanguageCode(locale?: string): string {
@@ -394,7 +411,7 @@ export class WhatsappService implements OnApplicationBootstrap {
   }
 
   private async ensureTrackingTable(): Promise<void> {
-    if (!this.dataSource || this.dataSource.options.type !== 'postgres') {
+    if (this.dataSource?.options.type !== 'postgres') {
       return;
     }
 
@@ -440,7 +457,7 @@ export class WhatsappService implements OnApplicationBootstrap {
   private async recordOutboundMessage(
     input: WhatsappOutboundLogInput,
   ): Promise<void> {
-    if (!this.dataSource || this.dataSource.options.type !== 'postgres') {
+    if (this.dataSource?.options.type !== 'postgres') {
       return;
     }
 
@@ -527,7 +544,7 @@ export class WhatsappService implements OnApplicationBootstrap {
   }
 
   private async updateMessageStatus(statusPayload: any): Promise<void> {
-    if (!this.dataSource || this.dataSource.options.type !== 'postgres') {
+    if (this.dataSource?.options.type !== 'postgres') {
       return;
     }
 
@@ -601,7 +618,7 @@ export class WhatsappService implements OnApplicationBootstrap {
     activityId: string,
     patch: Record<string, unknown>,
   ): Promise<void> {
-    if (!this.dataSource || this.dataSource.options.type !== 'postgres') {
+    if (this.dataSource?.options.type !== 'postgres') {
       return;
     }
 

--- a/backend/src/whatsapp/whatsapp.service.ts
+++ b/backend/src/whatsapp/whatsapp.service.ts
@@ -2,18 +2,55 @@ import {
   BadGatewayException,
   Injectable,
   Logger,
+  OnApplicationBootstrap,
+  Optional,
   ServiceUnavailableException,
   UnauthorizedException,
 } from '@nestjs/common';
-import { createHmac, timingSafeEqual } from 'node:crypto';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
+import { DataSource } from 'typeorm';
 
 export type WhatsappSendResult = {
   messageId: string | null;
   raw: unknown;
+  documentMessageId?: string | null;
+};
+
+export type WhatsappActivityEntity = 'tenant' | 'owner' | 'interested';
+export type WhatsappRelatedEntityType =
+  WhatsappActivityEntity | 'property_visit' | 'invoice' | 'payment' | 'lease';
+
+export type WhatsappMessageContext = {
+  companyId?: string;
+  relatedEntityType?: WhatsappRelatedEntityType;
+  relatedEntityId?: string;
+  activityEntity?: WhatsappActivityEntity;
+  activityId?: string;
+};
+
+export type WhatsappTemplateOptions = {
+  textFallback?: string;
+  pdfUrl?: string;
+  context?: WhatsappMessageContext;
+};
+
+type WhatsappOutboundLogInput = {
+  to: string;
+  messageType: 'text' | 'document' | 'template';
+  text?: string;
+  pdfUrl?: string;
+  templateName?: string;
+  templateLanguage?: string;
+  status: 'sent' | 'failed';
+  messageId?: string | null;
+  raw?: unknown;
+  errorMessage?: string;
+  context?: WhatsappMessageContext;
 };
 
 @Injectable()
-export class WhatsappService {
+export class WhatsappService implements OnApplicationBootstrap {
   private readonly logger = new Logger(WhatsappService.name);
 
   private readonly apiBaseUrl =
@@ -40,10 +77,21 @@ export class WhatsappService {
   private readonly enabled =
     (process.env.WHATSAPP_ENABLED ?? 'true').toLowerCase() !== 'false';
 
+  constructor(
+    @Optional()
+    @InjectDataSource()
+    private readonly dataSource?: DataSource,
+  ) {}
+
+  async onApplicationBootstrap(): Promise<void> {
+    await this.ensureTrackingTable();
+  }
+
   async sendTextMessage(
     to: string,
     text: string,
     pdfUrl?: string,
+    context?: WhatsappMessageContext,
   ): Promise<WhatsappSendResult> {
     if (!this.enabled) {
       throw new ServiceUnavailableException('WhatsApp messaging is disabled');
@@ -60,7 +108,6 @@ export class WhatsappService {
       throw new BadGatewayException('Invalid WhatsApp phone number');
     }
 
-    const url = `${this.apiBaseUrl.replace(/\/$/, '')}/${this.phoneNumberId}/messages`;
     const messageBody = text.trim();
     if (!messageBody) {
       throw new BadGatewayException('WhatsApp message body cannot be empty');
@@ -91,38 +138,85 @@ export class WhatsappService {
       };
     }
 
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${this.accessToken}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(payload),
+    return this.postOutboundPayload(payload, {
+      to: normalizedPhone,
+      messageType: pdfUrl ? 'document' : 'text',
+      text: messageBody,
+      pdfUrl,
+      context,
     });
+  }
 
-    const data: any = await response.json().catch(() => null);
-
-    if (!response.ok) {
-      const errorMessage =
-        data?.error?.message ??
-        `WhatsApp API request failed (${response.status})`;
-      this.logger.error('Failed to send WhatsApp message', {
-        status: response.status,
-        errorMessage,
-        to: normalizedPhone,
-      });
-      throw new BadGatewayException(errorMessage);
+  async sendTemplateMessage(
+    to: string,
+    templateName: string,
+    languageCode: string,
+    bodyParameters: string[],
+    options: WhatsappTemplateOptions = {},
+  ): Promise<WhatsappSendResult> {
+    if (!this.enabled) {
+      throw new ServiceUnavailableException('WhatsApp messaging is disabled');
     }
 
-    const messageId = (data?.messages?.[0]?.id as string | undefined) ?? null;
-    this.logger.log('WhatsApp message sent', {
+    if (!this.phoneNumberId || !this.accessToken) {
+      throw new ServiceUnavailableException(
+        'WhatsApp configuration is incomplete',
+      );
+    }
+
+    const normalizedPhone = this.normalizePhone(to);
+    if (!normalizedPhone) {
+      throw new BadGatewayException('Invalid WhatsApp phone number');
+    }
+
+    const normalizedTemplateName = templateName.trim();
+    if (!/^[a-z0-9_]{1,120}$/.test(normalizedTemplateName)) {
+      throw new BadGatewayException('Invalid WhatsApp template name');
+    }
+
+    const normalizedLanguage = this.resolveLanguageCode(languageCode);
+    const parameters = bodyParameters.map((value) => ({
+      type: 'text',
+      text: String(value ?? '').slice(0, 1024),
+    }));
+
+    const payload: Record<string, unknown> = {
+      messaging_product: 'whatsapp',
+      recipient_type: 'individual',
       to: normalizedPhone,
-      messageId,
+      type: 'template',
+      template: {
+        name: normalizedTemplateName,
+        language: { code: normalizedLanguage },
+        ...(parameters.length > 0
+          ? { components: [{ type: 'body', parameters }] }
+          : {}),
+      },
+    };
+
+    const templateResult = await this.postOutboundPayload(payload, {
+      to: normalizedPhone,
+      messageType: 'template',
+      text: options.textFallback,
+      templateName: normalizedTemplateName,
+      templateLanguage: normalizedLanguage,
+      context: options.context,
     });
 
+    if (!options.pdfUrl) {
+      return templateResult;
+    }
+
+    const documentResult = await this.sendTextMessage(
+      normalizedPhone,
+      options.textFallback ?? 'Documento disponible.',
+      options.pdfUrl,
+      options.context,
+    );
+
     return {
-      messageId,
-      raw: data,
+      ...templateResult,
+      documentMessageId: documentResult.messageId,
     };
   }
 
@@ -169,18 +263,50 @@ export class WhatsappService {
     }
   }
 
-  handleIncomingWebhook(payload: unknown): void {
-    const change = (payload as any)?.entry?.[0]?.changes?.[0]?.value;
-    const message = change?.messages?.[0];
+  async handleIncomingWebhook(payload: unknown): Promise<void> {
+    const entries = Array.isArray((payload as any)?.entry)
+      ? (payload as any).entry
+      : [];
+    let sawMessage = false;
+    let sawStatus = false;
 
-    if (!message) {
-      this.logger.debug('WhatsApp webhook received without messages');
-      return;
+    for (const entry of entries) {
+      const changes = Array.isArray(entry?.changes) ? entry.changes : [];
+      for (const item of changes) {
+        const value = item?.value;
+        const statuses = Array.isArray(value?.statuses) ? value.statuses : [];
+        for (const status of statuses) {
+          sawStatus = true;
+          await this.updateMessageStatus(status);
+        }
+
+        const messages = Array.isArray(value?.messages) ? value.messages : [];
+        for (const message of messages) {
+          sawMessage = true;
+          const from = message.from ?? 'unknown';
+          const text = message.text?.body ?? '[non-text-message]';
+          this.logger.log(`WhatsApp webhook message from ${from}: ${text}`);
+        }
+      }
     }
 
-    const from = message.from ?? 'unknown';
-    const text = message.text?.body ?? '[non-text-message]';
-    this.logger.log(`WhatsApp webhook message from ${from}: ${text}`);
+    if (!sawMessage && !sawStatus) {
+      this.logger.debug('WhatsApp webhook received without messages');
+    }
+  }
+
+  resolveLanguageCode(locale?: string): string {
+    const normalized = (locale || 'es_AR').replace('-', '_');
+    const aliases: Record<string, string> = {
+      es: 'es_AR',
+      es_AR: 'es_AR',
+      en: 'en_US',
+      en_US: 'en_US',
+      pt: 'pt_BR',
+      pt_BR: 'pt_BR',
+    };
+
+    return aliases[normalized] ?? 'es_AR';
   }
 
   private buildDocumentAccessUrl(pdfUrl: string): string {
@@ -213,6 +339,297 @@ export class WhatsappService {
     return createHmac('sha256', this.documentLinkSecret)
       .update(`${documentId}:${expiresAt}`)
       .digest('hex');
+  }
+
+  private async postOutboundPayload(
+    payload: Record<string, unknown>,
+    logInput: Omit<WhatsappOutboundLogInput, 'status' | 'raw' | 'errorMessage'>,
+  ): Promise<WhatsappSendResult> {
+    const url = `${this.apiBaseUrl.replace(/\/$/, '')}/${this.phoneNumberId}/messages`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const data: any = await response.json().catch(() => null);
+
+    if (!response.ok) {
+      const errorMessage =
+        data?.error?.message ??
+        `WhatsApp API request failed (${response.status})`;
+      this.logger.error('Failed to send WhatsApp message', {
+        status: response.status,
+        errorMessage,
+        to: logInput.to,
+      });
+      await this.recordOutboundMessage({
+        ...logInput,
+        status: 'failed',
+        raw: data,
+        errorMessage,
+      });
+      throw new BadGatewayException(errorMessage);
+    }
+
+    const messageId = (data?.messages?.[0]?.id as string | undefined) ?? null;
+    this.logger.log('WhatsApp message sent', {
+      to: logInput.to,
+      messageId,
+    });
+    await this.recordOutboundMessage({
+      ...logInput,
+      status: 'sent',
+      messageId,
+      raw: data,
+    });
+
+    return {
+      messageId,
+      raw: data,
+    };
+  }
+
+  private async ensureTrackingTable(): Promise<void> {
+    if (!this.dataSource || this.dataSource.options.type !== 'postgres') {
+      return;
+    }
+
+    await this.dataSource.query(`
+      CREATE TABLE IF NOT EXISTS whatsapp_messages (
+        id uuid PRIMARY KEY,
+        whatsapp_message_id varchar(255) UNIQUE,
+        recipient_phone varchar(32) NOT NULL,
+        direction varchar(16) NOT NULL DEFAULT 'outbound',
+        message_type varchar(32) NOT NULL,
+        template_name varchar(120),
+        template_language varchar(16),
+        text text,
+        pdf_url varchar(200),
+        status varchar(32) NOT NULL DEFAULT 'sent',
+        sent_at timestamptz,
+        delivered_at timestamptz,
+        read_at timestamptz,
+        failed_at timestamptz,
+        error_message text,
+        company_id uuid,
+        related_entity_type varchar(64),
+        related_entity_id uuid,
+        activity_entity varchar(32),
+        activity_id uuid,
+        raw_response jsonb NOT NULL DEFAULT '{}'::jsonb,
+        raw_status jsonb NOT NULL DEFAULT '{}'::jsonb,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now()
+      )
+    `);
+
+    await this.dataSource.query(`
+      CREATE INDEX IF NOT EXISTS idx_whatsapp_messages_activity
+      ON whatsapp_messages (activity_entity, activity_id)
+    `);
+    await this.dataSource.query(`
+      CREATE INDEX IF NOT EXISTS idx_whatsapp_messages_related
+      ON whatsapp_messages (related_entity_type, related_entity_id)
+    `);
+  }
+
+  private async recordOutboundMessage(
+    input: WhatsappOutboundLogInput,
+  ): Promise<void> {
+    if (!this.dataSource || this.dataSource.options.type !== 'postgres') {
+      return;
+    }
+
+    const sentAt = input.status === 'sent' ? new Date() : null;
+    const failedAt = input.status === 'failed' ? new Date() : null;
+    try {
+      await this.dataSource.query(
+        `
+          INSERT INTO whatsapp_messages (
+            id,
+            whatsapp_message_id,
+            recipient_phone,
+            message_type,
+            template_name,
+            template_language,
+            text,
+            pdf_url,
+            status,
+            sent_at,
+            failed_at,
+            error_message,
+            company_id,
+            related_entity_type,
+            related_entity_id,
+            activity_entity,
+            activity_id,
+            raw_response,
+            updated_at
+          )
+          VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+            $11, $12, $13, $14, $15, $16, $17, $18::jsonb, now()
+          )
+          ON CONFLICT (whatsapp_message_id)
+          DO UPDATE SET
+            status = EXCLUDED.status,
+            sent_at = COALESCE(whatsapp_messages.sent_at, EXCLUDED.sent_at),
+            failed_at = COALESCE(whatsapp_messages.failed_at, EXCLUDED.failed_at),
+            error_message = EXCLUDED.error_message,
+            raw_response = EXCLUDED.raw_response,
+            updated_at = now()
+        `,
+        [
+          randomUUID(),
+          input.messageId ?? null,
+          input.to,
+          input.messageType,
+          input.templateName ?? null,
+          input.templateLanguage ?? null,
+          input.text ?? null,
+          input.pdfUrl ?? null,
+          input.status,
+          sentAt,
+          failedAt,
+          input.errorMessage ?? null,
+          input.context?.companyId ?? null,
+          input.context?.relatedEntityType ?? null,
+          input.context?.relatedEntityId ?? null,
+          input.context?.activityEntity ?? null,
+          input.context?.activityId ?? null,
+          JSON.stringify(input.raw ?? {}),
+        ],
+      );
+
+      if (input.context?.activityEntity && input.context.activityId) {
+        await this.updateActivityMetadata(
+          input.context.activityEntity,
+          input.context.activityId,
+          {
+            messageId: input.messageId ?? null,
+            status: input.status,
+            sentAt: sentAt?.toISOString() ?? null,
+            failedAt: failedAt?.toISOString() ?? null,
+            templateName: input.templateName ?? null,
+            templateLanguage: input.templateLanguage ?? null,
+          },
+        );
+      }
+    } catch (error) {
+      this.logger.warn('Failed to record WhatsApp message tracking data', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private async updateMessageStatus(statusPayload: any): Promise<void> {
+    if (!this.dataSource || this.dataSource.options.type !== 'postgres') {
+      return;
+    }
+
+    const messageId = statusPayload?.id;
+    const status = statusPayload?.status;
+    if (
+      !messageId ||
+      !['sent', 'delivered', 'read', 'failed'].includes(status)
+    ) {
+      return;
+    }
+
+    const occurredAt = statusPayload?.timestamp
+      ? new Date(Number(statusPayload.timestamp) * 1000)
+      : new Date();
+    const errorMessage = Array.isArray(statusPayload?.errors)
+      ? statusPayload.errors
+          .map((item: any) => item?.message)
+          .filter(Boolean)
+          .join('; ') || null
+      : null;
+
+    const sentAt = status === 'sent' ? occurredAt : null;
+    const deliveredAt = status === 'delivered' ? occurredAt : null;
+    const readAt = status === 'read' ? occurredAt : null;
+    const failedAt = status === 'failed' ? occurredAt : null;
+
+    const rows = await this.dataSource.query(
+      `
+        UPDATE whatsapp_messages
+        SET
+          status = $2,
+          sent_at = COALESCE(sent_at, $3),
+          delivered_at = COALESCE(delivered_at, $4),
+          read_at = COALESCE(read_at, $5),
+          failed_at = COALESCE(failed_at, $6),
+          error_message = COALESCE($7, error_message),
+          raw_status = $8::jsonb,
+          updated_at = now()
+        WHERE whatsapp_message_id = $1
+        RETURNING activity_entity, activity_id
+      `,
+      [
+        messageId,
+        status,
+        sentAt,
+        deliveredAt,
+        readAt,
+        failedAt,
+        errorMessage,
+        JSON.stringify(statusPayload ?? {}),
+      ],
+    );
+
+    const row = rows?.[0];
+    if (row?.activity_entity && row?.activity_id) {
+      await this.updateActivityMetadata(row.activity_entity, row.activity_id, {
+        messageId,
+        status,
+        sentAt: sentAt?.toISOString() ?? undefined,
+        deliveredAt: deliveredAt?.toISOString() ?? undefined,
+        readAt: readAt?.toISOString() ?? undefined,
+        failedAt: failedAt?.toISOString() ?? undefined,
+        errorMessage: errorMessage ?? undefined,
+      });
+    }
+  }
+
+  private async updateActivityMetadata(
+    entity: WhatsappActivityEntity,
+    activityId: string,
+    patch: Record<string, unknown>,
+  ): Promise<void> {
+    if (!this.dataSource || this.dataSource.options.type !== 'postgres') {
+      return;
+    }
+
+    const tableByEntity: Record<WhatsappActivityEntity, string> = {
+      tenant: 'tenant_activities',
+      owner: 'owner_activities',
+      interested: 'interested_activities',
+    };
+    const table = tableByEntity[entity];
+    const cleanPatch = Object.fromEntries(
+      Object.entries(patch).filter(([, value]) => value !== undefined),
+    );
+
+    await this.dataSource.query(
+      `
+        UPDATE ${table}
+        SET
+          metadata = jsonb_set(
+            COALESCE(metadata, '{}'::jsonb),
+            '{whatsapp}',
+            COALESCE(metadata->'whatsapp', '{}'::jsonb) || $2::jsonb,
+            true
+          ),
+          updated_at = now()
+        WHERE id = $1
+      `,
+      [activityId, JSON.stringify(cleanPatch)],
+    );
   }
 
   private normalizePhone(phone: string): string {

--- a/batch/src/index.ts
+++ b/batch/src/index.ts
@@ -116,15 +116,27 @@ async function processReminderInvoice(
   }
 
   const tenantName = contact.tenantName || "inquilino/a";
+  const dueText = `en ${daysUntilDue} ${daysUntilDue === 1 ? "día" : "días"} (${invoice.dueDate.toISOString().slice(0, 10)})`;
+  const totalAmount = `${invoice.currencyCode} ${invoice.total.toLocaleString("es-AR", { minimumFractionDigits: 2 })}`;
   const text = [
     `Hola ${tenantName},`,
     `recordatorio de pago de la factura ${invoice.invoiceNumber}.`,
-    `Vence en ${daysUntilDue} ${daysUntilDue === 1 ? "día" : "días"} (${invoice.dueDate.toISOString().slice(0, 10)}).`,
-    `Monto: ${invoice.currencyCode} ${invoice.total.toLocaleString("es-AR", { minimumFractionDigits: 2 })}.`,
+    `Vence ${dueText}.`,
+    `Monto: ${totalAmount}.`,
   ].join(" ");
 
-  const result = await whatsappService.sendTextMessage(
+  const result = await whatsappService.sendTemplateMessage(
     contact.tenantPhone,
+    {
+      templateName: "payment_reminder",
+      templateLanguage: contact.tenantLanguage ?? "es",
+      templateParameters: [
+        tenantName,
+        invoice.invoiceNumber,
+        dueText,
+        totalAmount,
+      ],
+    },
     text,
   );
   return result.success ? { sent: 1, failed: 0 } : { sent: 0, failed: 1 };

--- a/batch/src/services/billing.service.ts
+++ b/batch/src/services/billing.service.ts
@@ -164,15 +164,26 @@ export class BillingService {
       const amount = invoice.total.toLocaleString("es-AR", {
         minimumFractionDigits: 2,
       });
+      const totalAmount = `${invoice.currencyCode} ${amount}`;
       const text = [
         `Hola ${tenantName},`,
         `tu factura ${invoice.invoiceNumber} ya está disponible.`,
         `Vencimiento: ${dueDate}.`,
-        `Monto: ${invoice.currencyCode} ${amount}.`,
+        `Monto: ${totalAmount}.`,
       ].join(" ");
 
-      const sendResult = await this.whatsappService.sendTextMessage(
+      const sendResult = await this.whatsappService.sendTemplateMessage(
         contact.tenantPhone,
+        {
+          templateName: "invoice_available",
+          templateLanguage: contact.tenantLanguage ?? "es",
+          templateParameters: [
+            tenantName,
+            invoice.invoiceNumber,
+            dueDate,
+            totalAmount,
+          ],
+        },
         text,
         invoice.pdfUrl,
       );

--- a/batch/src/services/invoice.service.ts
+++ b/batch/src/services/invoice.service.ts
@@ -95,6 +95,7 @@ export interface InvoiceRecord {
 export interface InvoiceReminderContact {
   tenantPhone: string | null;
   tenantName: string | null;
+  tenantLanguage: string | null;
 }
 
 /**
@@ -244,7 +245,8 @@ export class InvoiceService {
     const result = await AppDataSource.query(
       `SELECT
           tu.phone AS tenant_phone,
-          CONCAT_WS(' ', tu.first_name, tu.last_name) AS tenant_name
+          CONCAT_WS(' ', tu.first_name, tu.last_name) AS tenant_name,
+          tu.language AS tenant_language
        FROM invoices i
        JOIN leases l ON l.id = i.lease_id
        JOIN tenants t ON t.id = l.tenant_id
@@ -257,11 +259,13 @@ export class InvoiceService {
     const row = (result[0] ?? {}) as {
       tenant_phone?: string | null;
       tenant_name?: string | null;
+      tenant_language?: string | null;
     };
 
     return {
       tenantPhone: row.tenant_phone ?? null,
       tenantName: row.tenant_name ?? null,
+      tenantLanguage: row.tenant_language ?? null,
     };
   }
 

--- a/batch/src/services/lease-renewal.service.spec.ts
+++ b/batch/src/services/lease-renewal.service.spec.ts
@@ -18,7 +18,7 @@ jest.mock("../shared/logger", () => ({
 describe("LeaseRenewalService", () => {
   const queryMock = AppDataSource.query as jest.Mock;
   const whatsappService = {
-    sendTextMessage: jest.fn(),
+    sendTemplateMessage: jest.fn(),
   };
 
   let service: LeaseRenewalService;
@@ -105,7 +105,7 @@ describe("LeaseRenewalService", () => {
       errorLog: [],
     });
     expect(queryMock).toHaveBeenCalledTimes(1);
-    expect(whatsappService.sendTextMessage).not.toHaveBeenCalled();
+    expect(whatsappService.sendTemplateMessage).not.toHaveBeenCalled();
     expect(logger.info).toHaveBeenCalledWith(
       "Dry run: renewal alert would be created",
       expect.objectContaining({ leaseId: "lease-monthly-due", leadDays: 30 }),
@@ -137,7 +137,7 @@ describe("LeaseRenewalService", () => {
       ])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([]);
-    whatsappService.sendTextMessage.mockResolvedValue({
+    whatsappService.sendTemplateMessage.mockResolvedValue({
       success: true,
       messageId: "wamid-1",
     });
@@ -164,8 +164,13 @@ describe("LeaseRenewalService", () => {
         "Renovar alquiler de Casa 1",
       ]),
     );
-    expect(whatsappService.sendTextMessage).toHaveBeenCalledWith(
+    expect(whatsappService.sendTemplateMessage).toHaveBeenCalledWith(
       "+5491111111111",
+      {
+        templateName: "lease_renewal_alert_owner",
+        templateLanguage: "es",
+        templateParameters: ["Owner 1", "Casa 1", "2026-02-14", "Tenant 1"],
+      },
       expect.stringContaining("Casa 1 vence el 2026-02-14"),
     );
     expect(queryMock).toHaveBeenNthCalledWith(
@@ -204,7 +209,7 @@ describe("LeaseRenewalService", () => {
 
     expect(result.recordsProcessed).toBe(1);
     expect(result.whatsappSent).toBe(0);
-    expect(whatsappService.sendTextMessage).not.toHaveBeenCalled();
+    expect(whatsappService.sendTemplateMessage).not.toHaveBeenCalled();
   });
 
   it("records failures without stopping the remaining batch", async () => {

--- a/batch/src/services/lease-renewal.service.ts
+++ b/batch/src/services/lease-renewal.service.ts
@@ -13,6 +13,7 @@ type LeaseRenewalRecord = {
   ownerId: string;
   ownerName: string | null;
   ownerPhone: string | null;
+  ownerLanguage: string | null;
   tenantName: string | null;
   endDate: Date;
   renewalAlertPeriodicity: RenewalAlertPeriodicity;
@@ -108,6 +109,7 @@ export class LeaseRenewalService {
           l.owner_id,
           CONCAT_WS(' ', ou.first_name, ou.last_name) AS owner_name,
           ou.phone AS owner_phone,
+          ou.language AS owner_language,
           CONCAT_WS(' ', tu.first_name, tu.last_name) AS tenant_name,
           l.end_date,
           l.renewal_alert_periodicity,
@@ -150,6 +152,7 @@ export class LeaseRenewalService {
         owner_id: string;
         owner_name: string | null;
         owner_phone: string | null;
+        owner_language: string | null;
         tenant_name: string | null;
         end_date: string | Date;
         renewal_alert_periodicity: RenewalAlertPeriodicity;
@@ -164,6 +167,7 @@ export class LeaseRenewalService {
         ownerId: row.owner_id,
         ownerName: row.owner_name?.trim() || null,
         ownerPhone: row.owner_phone,
+        ownerLanguage: row.owner_language ?? null,
         tenantName: row.tenant_name?.trim() || null,
         endDate: new Date(row.end_date),
         renewalAlertPeriodicity: row.renewal_alert_periodicity,
@@ -268,17 +272,30 @@ export class LeaseRenewalService {
       return false;
     }
 
+    const ownerName = lease.ownerName || "propietario/a";
+    const endDate = lease.endDate.toISOString().slice(0, 10);
+    const tenantName = lease.tenantName || "Sin inquilino informado";
     const text = [
-      `Hola ${lease.ownerName || "propietario/a"},`,
-      `el contrato de ${lease.propertyName} vence el ${lease.endDate.toISOString().slice(0, 10)}.`,
+      `Hola ${ownerName},`,
+      `el contrato de ${lease.propertyName} vence el ${endDate}.`,
       lease.tenantName ? `Inquilino: ${lease.tenantName}.` : null,
       "Conviene revisar la renovacion con anticipacion.",
     ]
       .filter(Boolean)
       .join(" ");
 
-    const response = await this.whatsappService.sendTextMessage(
+    const response = await this.whatsappService.sendTemplateMessage(
       lease.ownerPhone,
+      {
+        templateName: "lease_renewal_alert_owner",
+        templateLanguage: lease.ownerLanguage ?? "es",
+        templateParameters: [
+          ownerName,
+          lease.propertyName,
+          endDate,
+          tenantName,
+        ],
+      },
       text,
     );
 

--- a/batch/src/services/whatsapp.service.spec.ts
+++ b/batch/src/services/whatsapp.service.spec.ts
@@ -71,6 +71,47 @@ describe("WhatsappService", () => {
     expect(result).toEqual({ success: true, messageId: "msg-123" });
   });
 
+  it("sends template payloads successfully", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        messageId: "tpl-123",
+        documentMessageId: "doc-123",
+      }),
+    });
+    const service = new WhatsappService();
+
+    const result = await service.sendTemplateMessage(
+      "54911",
+      {
+        templateName: "invoice_available",
+        templateLanguage: "es_AR",
+        templateParameters: ["Juan", "F-1", "2026-07-15", "ARS 1000,00"],
+      },
+      "fallback",
+      "db://document/123e4567-e89b-12d3-a456-426614174000",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3010/whatsapp/messages/internal",
+      expect.objectContaining({
+        body: JSON.stringify({
+          to: "54911",
+          text: "fallback",
+          pdfUrl: "db://document/123e4567-e89b-12d3-a456-426614174000",
+          templateName: "invoice_available",
+          templateLanguage: "es_AR",
+          templateParameters: ["Juan", "F-1", "2026-07-15", "ARS 1000,00"],
+        }),
+      }),
+    );
+    expect(result).toEqual({
+      success: true,
+      messageId: "tpl-123",
+      documentMessageId: "doc-123",
+    });
+  });
+
   it("returns HTTP error detail from backend response", async () => {
     fetchMock.mockResolvedValue({
       ok: false,

--- a/batch/src/services/whatsapp.service.ts
+++ b/batch/src/services/whatsapp.service.ts
@@ -3,7 +3,14 @@ import { logger } from "../shared/logger";
 export interface WhatsappSendResult {
   success: boolean;
   messageId?: string | null;
+  documentMessageId?: string | null;
   error?: string;
+}
+
+export interface WhatsappTemplatePayload {
+  templateName: string;
+  templateLanguage?: string;
+  templateParameters?: string[];
 }
 
 export class WhatsappService {
@@ -16,6 +23,31 @@ export class WhatsappService {
     text: string,
     pdfUrl?: string,
   ): Promise<WhatsappSendResult> {
+    return this.sendMessage({ to, text, pdfUrl });
+  }
+
+  async sendTemplateMessage(
+    to: string,
+    template: WhatsappTemplatePayload,
+    text: string,
+    pdfUrl?: string,
+  ): Promise<WhatsappSendResult> {
+    return this.sendMessage({
+      to,
+      text,
+      pdfUrl,
+      ...template,
+    });
+  }
+
+  private async sendMessage(payload: {
+    to: string;
+    text: string;
+    pdfUrl?: string;
+    templateName?: string;
+    templateLanguage?: string;
+    templateParameters?: string[];
+  }): Promise<WhatsappSendResult> {
     if (!this.internalToken) {
       return {
         success: false,
@@ -32,7 +64,7 @@ export class WhatsappService {
           "Content-Type": "application/json",
           "x-batch-whatsapp-token": this.internalToken,
         },
-        body: JSON.stringify({ to, text, pdfUrl }),
+        body: JSON.stringify(payload),
       });
 
       const data: any = await response.json().catch(() => ({}));
@@ -41,20 +73,27 @@ export class WhatsappService {
         const errorMsg =
           data?.message || data?.error || `HTTP ${response.status}`;
         logger.error("Batch WhatsApp send failed", {
-          to,
+          to: payload.to,
           status: response.status,
           error: errorMsg,
         });
         return { success: false, error: String(errorMsg) };
       }
 
+      const documentMessageId =
+        (data?.documentMessageId as string | null | undefined) ?? null;
+
       return {
         success: true,
         messageId: (data?.messageId as string | null | undefined) ?? null,
+        ...(documentMessageId ? { documentMessageId } : {}),
       };
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
-      logger.error("Batch WhatsApp request failed", { to, error: errorMsg });
+      logger.error("Batch WhatsApp request failed", {
+        to: payload.to,
+        error: errorMsg,
+      });
       return { success: false, error: errorMsg };
     }
   }

--- a/frontend/src/app/[locale]/interested/[id]/activities/new/page.tsx
+++ b/frontend/src/app/[locale]/interested/[id]/activities/new/page.tsx
@@ -111,7 +111,7 @@ export default function InterestedActivityCreatePage() {
 
     try {
       setSaving(true);
-      await interestedApi.addActivity(profile.id, {
+      const activity = await interestedApi.addActivity(profile.id, {
         type: form.type,
         subject: form.subject.trim(),
         body: form.body.trim() || undefined,
@@ -127,6 +127,10 @@ export default function InterestedActivityCreatePage() {
         await whatsappApi.sendMessage({
           to: profile.phone.trim(),
           text,
+          activityEntity: "interested",
+          activityId: activity.id,
+          relatedEntityType: "interested",
+          relatedEntityId: profile.id,
         });
       }
 

--- a/frontend/src/app/[locale]/tenants/[id]/activities/new/page.tsx
+++ b/frontend/src/app/[locale]/tenants/[id]/activities/new/page.tsx
@@ -138,7 +138,7 @@ export default function TenantActivityCreatePage() {
 
     try {
       setSaving(true);
-      await tenantsApi.createActivity(tenant.id, {
+      const activity = await tenantsApi.createActivity(tenant.id, {
         type: form.type,
         subject: form.subject.trim(),
         body: form.body.trim() || undefined,
@@ -152,6 +152,10 @@ export default function TenantActivityCreatePage() {
         await whatsappApi.sendMessage({
           to: tenant.phone.trim(),
           text,
+          activityEntity: "tenant",
+          activityId: activity.id,
+          relatedEntityType: "tenant",
+          relatedEntityId: tenant.id,
         });
       }
 

--- a/frontend/src/lib/api/whatsapp.ts
+++ b/frontend/src/lib/api/whatsapp.ts
@@ -5,6 +5,21 @@ export type SendWhatsappInput = {
   to: string;
   text: string;
   pdfUrl?: string;
+  templateName?: string;
+  templateLanguage?: string;
+  templateParameters?: string[];
+  activityEntity?: "tenant" | "owner" | "interested";
+  activityId?: string;
+  relatedEntityType?:
+    | "tenant"
+    | "owner"
+    | "interested"
+    | "property_visit"
+    | "invoice"
+    | "payment"
+    | "lease";
+  relatedEntityId?: string;
+  companyId?: string;
 };
 
 export type SendWhatsappResponse = {

--- a/mobile/app/(app)/(tabs)/_layout.tsx
+++ b/mobile/app/(app)/(tabs)/_layout.tsx
@@ -136,6 +136,12 @@ function TenantsHeaderLeft() {
   return <DashboardHeaderBackButton testID="header.back.tenants" />;
 }
 
+function TenantsHeaderRight() {
+  return (
+    <NewRouteHeaderAction route="/(app)/tenants/new" testID="tenants.new" />
+  );
+}
+
 function InterestedHeaderLeft() {
   return <DashboardHeaderBackButton testID="header.back.interested" />;
 }
@@ -207,6 +213,7 @@ export default function TabsLayout() {
             title: t('tenants.title'),
             tabBarButtonTestID: 'tab.tenants',
             headerLeft: TenantsHeaderLeft,
+            headerRight: TenantsHeaderRight,
             tabBarIcon: TenantsTabBarIcon,
           }}
         />

--- a/mobile/app/(app)/(tabs)/properties.tsx
+++ b/mobile/app/(app)/(tabs)/properties.tsx
@@ -280,9 +280,10 @@ export default function PropertiesScreen() {
                 <ActionChip
                   title={t('properties.addPropertyForOwner')}
                   onPress={() =>
-                    router.push(
-                      `/(app)/properties/new?ownerId=${encodeURIComponent(owner.id)}` as never,
-                    )
+                    router.push({
+                      pathname: '/(app)/properties/new',
+                      params: { ownerId: owner.id },
+                    } as never)
                   }
                   testID={`owner.addProperty.${owner.id}`}
                 />

--- a/mobile/app/(app)/properties/[id]/index.tsx
+++ b/mobile/app/(app)/properties/[id]/index.tsx
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { StyleSheet, Text, View } from 'react-native';
+import { Alert, StyleSheet, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
 import { ownersApi } from '@/api/owners';
@@ -184,7 +184,8 @@ function PropertyMaintenanceCard({
 }
 
 type PropertyActionsProps = Readonly<{
-  propertyId: string;
+  deleting: boolean;
+  onDelete: () => void;
   onEdit: () => void;
   onNewMaintenance: () => void;
   onNewVisit: () => void;
@@ -192,7 +193,8 @@ type PropertyActionsProps = Readonly<{
 }>;
 
 function PropertyActions({
-  propertyId,
+  deleting,
+  onDelete,
   onEdit,
   onNewMaintenance,
   onNewVisit,
@@ -217,7 +219,14 @@ function PropertyActions({
       <AppButton
         title={t('common.edit')}
         onPress={onEdit}
-        testID={`propertyDetail.edit.${propertyId}`}
+        testID="propertyDetail.edit"
+      />
+      <AppButton
+        title={t('common.delete')}
+        variant="secondary"
+        loading={deleting}
+        onPress={onDelete}
+        testID="propertyDetail.delete"
       />
     </View>
   );
@@ -226,6 +235,7 @@ function PropertyActions({
 export default function PropertyDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { t } = useTranslation();
 
   const propertyQuery = useQuery({
@@ -252,6 +262,23 @@ export default function PropertyDetailScreen() {
     enabled: Boolean(propertyQuery.data?.ownerId),
   });
 
+  const deleteMutation = useMutation({
+    mutationFn: () => propertiesApi.delete(id),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['properties'] }),
+        queryClient.invalidateQueries({ queryKey: ['leases'] }),
+      ]);
+      router.replace('/(app)/(tabs)/properties');
+    },
+    onError: (error) => {
+      Alert.alert(
+        t('common.error'),
+        error instanceof Error ? error.message : t('properties.deleteError'),
+      );
+    },
+  });
+
   const property = propertyQuery.data;
   const ownerName = getOwnerDisplayName(
     ownerQuery.data?.firstName,
@@ -265,6 +292,16 @@ export default function PropertyDetailScreen() {
     router.push(`/(app)/properties/${id}/maintenance/new` as never);
   const openEditProperty = () =>
     router.push(`/(app)/properties/${id}/edit` as never);
+  const confirmDeleteProperty = () => {
+    Alert.alert(t('common.delete'), t('properties.deleteConfirm'), [
+      { text: t('common.cancel'), style: 'cancel' },
+      {
+        text: t('common.delete'),
+        style: 'destructive',
+        onPress: () => deleteMutation.mutate(),
+      },
+    ]);
+  };
 
   return (
     <Screen>
@@ -302,10 +339,11 @@ export default function PropertyDetailScreen() {
 
       {property ? (
         <PropertyActions
+          deleting={deleteMutation.isPending}
+          onDelete={confirmDeleteProperty}
           onEdit={openEditProperty}
           onNewMaintenance={openNewMaintenance}
           onNewVisit={openNewVisit}
-          propertyId={property.id}
           t={t}
         />
       ) : null}

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -4,13 +4,11 @@ import '@/i18n';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { LogBox } from 'react-native';
-import { enableScreens } from 'react-native-screens';
 
 import { IS_E2E_MODE } from '@/api/env';
 import { AppProviders } from '@/providers/app-providers';
 
 if (IS_E2E_MODE) {
-  enableScreens(false);
   LogBox.ignoreAllLogs(true);
 }
 

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -4,11 +4,13 @@ import '@/i18n';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { LogBox } from 'react-native';
+import { enableScreens } from 'react-native-screens';
 
 import { IS_E2E_MODE } from '@/api/env';
 import { AppProviders } from '@/providers/app-providers';
 
 if (IS_E2E_MODE) {
+  enableScreens(false);
   LogBox.ignoreAllLogs(true);
 }
 

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -3,8 +3,14 @@ import '@/i18n';
 
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { LogBox } from 'react-native';
 
+import { IS_E2E_MODE } from '@/api/env';
 import { AppProviders } from '@/providers/app-providers';
+
+if (IS_E2E_MODE) {
+  LogBox.ignoreAllLogs(true);
+}
 
 export default function RootLayout() {
   return (

--- a/mobile/e2e/01-auth-and-navigation.e2e.ts
+++ b/mobile/e2e/01-auth-and-navigation.e2e.ts
@@ -9,7 +9,7 @@ describe('Auth and navigation', () => {
     await loginAsAdmin();
 
     await element(by.id('tab.properties')).tap();
-    await expect(element(by.id('properties.new'))).toBeVisible();
+    await expect(element(by.id('properties.owners.search'))).toBeVisible();
 
     await element(by.id('tab.tenants')).tap();
     await expect(element(by.id('tenants.new'))).toBeVisible();

--- a/mobile/e2e/02-properties-crud.e2e.ts
+++ b/mobile/e2e/02-properties-crud.e2e.ts
@@ -1,4 +1,8 @@
-import { loginAsAdmin, relaunchFreshApp, tapAndConfirmDeletion } from './helpers';
+import {
+  loginAsAdmin,
+  relaunchFreshApp,
+  tapAndConfirmDeletion,
+} from './helpers';
 
 describe('Properties CRUD', () => {
   beforeAll(async () => {
@@ -11,7 +15,10 @@ describe('Properties CRUD', () => {
     const updatedName = `${uniqueName} Updated`;
 
     await element(by.id('tab.properties')).tap();
-    await element(by.id('properties.new')).tap();
+    await waitFor(element(by.id('owner.addProperty.owner-1')))
+      .toBeVisible()
+      .withTimeout(15000);
+    await element(by.id('owner.addProperty.owner-1')).tap();
 
     await element(by.id('propertyCreate.name')).replaceText(uniqueName);
     await element(by.id('propertyCreate.street')).replaceText('Avenida Test');
@@ -35,10 +42,14 @@ describe('Properties CRUD', () => {
       .scroll(220, 'down');
     await element(by.id('propertyCreate.submit')).tap();
 
-    await waitFor(element(by.id('propertyDetail.edit'))).toBeVisible().withTimeout(15000);
+    await waitFor(element(by.id('propertyDetail.edit')))
+      .toBeVisible()
+      .withTimeout(15000);
 
     await element(by.id('propertyDetail.edit')).tap();
-    await waitFor(element(by.id('propertyEdit.name'))).toBeVisible().withTimeout(10000);
+    await waitFor(element(by.id('propertyEdit.name')))
+      .toBeVisible()
+      .withTimeout(10000);
     await element(by.id('propertyEdit.name')).replaceText(updatedName);
     await waitFor(element(by.id('propertyEdit.submit')))
       .toBeVisible()
@@ -46,9 +57,13 @@ describe('Properties CRUD', () => {
       .scroll(220, 'down');
     await element(by.id('propertyEdit.submit')).tap();
 
-    await waitFor(element(by.text(updatedName))).toBeVisible().withTimeout(15000);
+    await waitFor(element(by.text(updatedName)))
+      .toBeVisible()
+      .withTimeout(15000);
 
     await tapAndConfirmDeletion('propertyDetail.delete');
-    await waitFor(element(by.id('properties.new'))).toBeVisible().withTimeout(15000);
+    await waitFor(element(by.id('owner.addProperty.owner-1')))
+      .toBeVisible()
+      .withTimeout(15000);
   });
 });

--- a/mobile/e2e/02-properties-crud.e2e.ts
+++ b/mobile/e2e/02-properties-crud.e2e.ts
@@ -23,7 +23,16 @@ describe('Properties CRUD', () => {
     await element(by.id('propertyCreate.name')).replaceText(uniqueName);
     await element(by.id('propertyCreate.street')).replaceText('Avenida Test');
     await element(by.id('propertyCreate.number')).replaceText('123');
+    await device.pressBack();
+    await waitFor(element(by.id('propertyCreate.city')))
+      .toBeVisible()
+      .whileElement(by.id('propertyCreate.scroll'))
+      .scroll(220, 'down');
     await element(by.id('propertyCreate.city')).replaceText('CABA');
+    await waitFor(element(by.id('propertyCreate.state')))
+      .toBeVisible()
+      .whileElement(by.id('propertyCreate.scroll'))
+      .scroll(120, 'down');
     await element(by.id('propertyCreate.state')).replaceText('Buenos Aires');
     await waitFor(element(by.id('propertyCreate.zipCode')))
       .toBeVisible()

--- a/mobile/e2e/02-properties-crud.e2e.ts
+++ b/mobile/e2e/02-properties-crud.e2e.ts
@@ -26,7 +26,6 @@ describe('Properties CRUD', () => {
     await element(by.id('propertyCreate.name')).replaceText(uniqueName);
     await element(by.id('propertyCreate.street')).replaceText('Avenida Test');
     await element(by.id('propertyCreate.number')).replaceText('123');
-    await device.pressBack();
     await waitFor(element(by.id('propertyCreate.city')))
       .toBeVisible()
       .whileElement(by.id('propertyCreate.scroll'))

--- a/mobile/e2e/02-properties-crud.e2e.ts
+++ b/mobile/e2e/02-properties-crud.e2e.ts
@@ -20,6 +20,9 @@ describe('Properties CRUD', () => {
       .withTimeout(15000);
     await element(by.id('owner.addProperty.owner-1')).tap();
 
+    await waitFor(element(by.id('propertyCreate.name')))
+      .toBeVisible()
+      .withTimeout(15000);
     await element(by.id('propertyCreate.name')).replaceText(uniqueName);
     await element(by.id('propertyCreate.street')).replaceText('Avenida Test');
     await element(by.id('propertyCreate.number')).replaceText('123');

--- a/mobile/e2e/06-users-templates-critical.e2e.ts
+++ b/mobile/e2e/06-users-templates-critical.e2e.ts
@@ -2,6 +2,7 @@ import {
   dismissNativeAlertIfVisible,
   loginAsAdmin,
   relaunchFreshApp,
+  tapAndConfirmDeletion,
 } from './helpers';
 
 describe('Users and templates critical flows', () => {
@@ -17,7 +18,9 @@ describe('Users and templates critical flows', () => {
     await element(by.id('tab.settings')).tap();
     await element(by.id('settings.goto.users')).tap();
 
-    await waitFor(element(by.id('users.new'))).toBeVisible().withTimeout(15000);
+    await waitFor(element(by.id('users.new')))
+      .toBeVisible()
+      .withTimeout(15000);
     await element(by.id('users.new')).tap();
 
     await element(by.id('userCreate.email')).replaceText(email);
@@ -33,18 +36,26 @@ describe('Users and templates critical flows', () => {
       .scroll(240, 'down');
     await element(by.id('userCreate.submit')).tap();
 
-    await waitFor(element(by.id('userDetail.edit'))).toBeVisible().withTimeout(15000);
+    await waitFor(element(by.id('userDetail.edit')))
+      .toBeVisible()
+      .withTimeout(15000);
 
     await element(by.id('userDetail.resetPassword')).tap();
-    await waitFor(element(by.id('userResetPassword.newPassword'))).toBeVisible().withTimeout(10000);
-    await element(by.id('userResetPassword.newPassword')).replaceText('SecurePass456!');
+    await waitFor(element(by.id('userResetPassword.newPassword')))
+      .toBeVisible()
+      .withTimeout(10000);
+    await element(by.id('userResetPassword.newPassword')).replaceText(
+      'SecurePass456!',
+    );
     await element(by.id('userResetPassword.submit')).tap();
     await dismissNativeAlertIfVisible();
 
     await element(by.id('userDetail.toggleActivation')).tap();
 
     await element(by.id('userDetail.edit')).tap();
-    await waitFor(element(by.id('userEdit.firstName'))).toBeVisible().withTimeout(10000);
+    await waitFor(element(by.id('userEdit.firstName')))
+      .toBeVisible()
+      .withTimeout(10000);
     await element(by.id('userEdit.firstName')).replaceText('E2EUpdated');
 
     await waitFor(element(by.id('userEdit.submit')))
@@ -53,7 +64,9 @@ describe('Users and templates critical flows', () => {
       .scroll(220, 'down');
     await element(by.id('userEdit.submit')).tap();
 
-    await waitFor(element(by.text('E2EUpdated User'))).toBeVisible().withTimeout(15000);
+    await waitFor(element(by.text('E2EUpdated User')))
+      .toBeVisible()
+      .withTimeout(15000);
   });
 
   it('templates flow: create, edit and delete payment template', async () => {
@@ -64,13 +77,17 @@ describe('Users and templates critical flows', () => {
     await element(by.id('tab.settings')).tap();
     await element(by.id('settings.goto.templates')).tap();
 
-    await waitFor(element(by.id('templates.new'))).toBeVisible().withTimeout(15000);
+    await waitFor(element(by.id('templates.new')))
+      .toBeVisible()
+      .withTimeout(15000);
     await element(by.id('templates.new')).tap();
 
     await element(by.id('templateCreate.kind.payment')).tap();
     await element(by.id('templateCreate.paymentType.receipt')).tap();
     await element(by.id('templateCreate.name')).replaceText(templateName);
-    await element(by.id('templateCreate.templateBody')).replaceText('Contenido base E2E {{receipt.number}}');
+    await element(by.id('templateCreate.templateBody')).replaceText(
+      'Contenido base E2E {{receipt.number}}',
+    );
     await element(by.id('templateCreate.isDefault.yes')).tap();
 
     await waitFor(element(by.id('templateCreate.submit')))
@@ -79,10 +96,14 @@ describe('Users and templates critical flows', () => {
       .scroll(220, 'down');
     await element(by.id('templateCreate.submit')).tap();
 
-    await waitFor(element(by.id('templateDetail.edit'))).toBeVisible().withTimeout(15000);
+    await waitFor(element(by.id('templateDetail.edit')))
+      .toBeVisible()
+      .withTimeout(15000);
 
     await element(by.id('templateDetail.edit')).tap();
-    await waitFor(element(by.id('templateEdit.name'))).toBeVisible().withTimeout(10000);
+    await waitFor(element(by.id('templateEdit.name')))
+      .toBeVisible()
+      .withTimeout(10000);
     await element(by.id('templateEdit.name')).replaceText(updatedTemplateName);
     await element(by.id('templateEdit.isActive.no')).tap();
 
@@ -92,9 +113,13 @@ describe('Users and templates critical flows', () => {
       .scroll(220, 'down');
     await element(by.id('templateEdit.submit')).tap();
 
-    await waitFor(element(by.text(updatedTemplateName))).toBeVisible().withTimeout(15000);
+    await waitFor(element(by.text(updatedTemplateName)))
+      .toBeVisible()
+      .withTimeout(15000);
 
     await tapAndConfirmDeletion('templateDetail.delete');
-    await waitFor(element(by.id('templates.new'))).toBeVisible().withTimeout(15000);
+    await waitFor(element(by.id('templates.new')))
+      .toBeVisible()
+      .withTimeout(15000);
   });
 });

--- a/mobile/e2e/helpers.ts
+++ b/mobile/e2e/helpers.ts
@@ -44,23 +44,23 @@ export async function tapAndConfirmDeletion(
 ): Promise<void> {
   await element(by.id(deleteButtonId)).tap();
 
+  const androidPositiveButton = element(by.id('android:id/button1'));
+  const hasAndroidPositiveButton = await waitFor(androidPositiveButton)
+    .toBeVisible()
+    .withTimeout(1000)
+    .then(() => true)
+    .catch(() => false);
+  if (hasAndroidPositiveButton) {
+    await androidPositiveButton.tap();
+    return;
+  }
+
   try {
     await waitFor(element(by.text('Eliminar')).atIndex(1))
       .toBeVisible()
       .withTimeout(5000);
     await element(by.text('Eliminar')).atIndex(1).tap();
   } catch {
-    const androidPositiveButton = element(by.id('android:id/button1'));
-    const hasAndroidPositiveButton = await waitFor(androidPositiveButton)
-      .toBeVisible()
-      .withTimeout(1000)
-      .then(() => true)
-      .catch(() => false);
-    if (hasAndroidPositiveButton) {
-      await androidPositiveButton.tap();
-      return;
-    }
-
     await waitFor(element(by.text('Eliminar')))
       .toBeVisible()
       .withTimeout(5000);

--- a/mobile/e2e/helpers.ts
+++ b/mobile/e2e/helpers.ts
@@ -7,6 +7,10 @@ export async function relaunchFreshApp(): Promise<void> {
   });
 }
 
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export async function loginAsAdmin(): Promise<void> {
   const isAlreadyLoggedIn = await waitFor(element(by.id('tab.properties')))
     .toBeVisible()
@@ -27,16 +31,23 @@ export async function loginAsAdmin(): Promise<void> {
 
   await element(by.id('login.submit')).tap();
 
+  await sleep(1500);
+  await relaunchFreshApp();
+
   await waitFor(element(by.id('tab.properties')))
     .toBeVisible()
     .withTimeout(20000);
 }
 
-export async function tapAndConfirmDeletion(deleteButtonId: string): Promise<void> {
+export async function tapAndConfirmDeletion(
+  deleteButtonId: string,
+): Promise<void> {
   await element(by.id(deleteButtonId)).tap();
 
   try {
-    await waitFor(element(by.text('Eliminar')).atIndex(1)).toBeVisible().withTimeout(5000);
+    await waitFor(element(by.text('Eliminar')).atIndex(1))
+      .toBeVisible()
+      .withTimeout(5000);
     await element(by.text('Eliminar')).atIndex(1).tap();
   } catch {
     const androidPositiveButton = element(by.id('android:id/button1'));
@@ -50,7 +61,9 @@ export async function tapAndConfirmDeletion(deleteButtonId: string): Promise<voi
       return;
     }
 
-    await waitFor(element(by.text('Eliminar'))).toBeVisible().withTimeout(5000);
+    await waitFor(element(by.text('Eliminar')))
+      .toBeVisible()
+      .withTimeout(5000);
     await element(by.text('Eliminar')).tap();
   }
 }

--- a/mobile/index.js
+++ b/mobile/index.js
@@ -1,0 +1,6 @@
+if (process.env.EXPO_PUBLIC_E2E_MODE === 'true') {
+  const { enableScreens } = require('react-native-screens');
+  enableScreens(false);
+}
+
+require('expo-router/entry');

--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -28,4 +28,24 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
   return context.resolveRequest(context, moduleName, platform);
 };
 
+const enhanceMiddleware = config.server?.enhanceMiddleware;
+config.server = {
+  ...config.server,
+  enhanceMiddleware: (middleware, server) => {
+    const enhancedMiddleware = enhanceMiddleware
+      ? enhanceMiddleware(middleware, server)
+      : middleware;
+
+    return (req, res, next) => {
+      if (req.url?.split('?')[0] === '/status') {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('packager-status:running');
+        return;
+      }
+
+      return enhancedMiddleware(req, res, next);
+    };
+  },
+};
+
 module.exports = config;

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rent",
   "version": "1.0.0",
-  "main": "expo-router/entry",
+  "main": "index.js",
   "scripts": {
     "start": "expo start",
     "android": "expo run:android",

--- a/mobile/scripts/e2e-android-test.sh
+++ b/mobile/scripts/e2e-android-test.sh
@@ -24,7 +24,7 @@ rm -rf "$DETOX_ARTIFACTS"
 rm -f "$METRO_LOG" "$LOGCAT_LOG" /tmp/rent-e2e-entry-*.bundle /tmp/rent-e2e-metro-status.txt
 
 if [ "$APP_BUILD_TYPE" = "debug" ]; then
-  EXPO_PUBLIC_MOCK_MODE=true EXPO_PUBLIC_E2E_MODE=true CI=1 \
+  EXPO_PUBLIC_MOCK_MODE=true EXPO_PUBLIC_E2E_MODE=true CI=1 BROWSER=none \
     ./node_modules/.bin/expo start \
     --localhost \
     --port 8081 \

--- a/mobile/scripts/e2e-android-test.sh
+++ b/mobile/scripts/e2e-android-test.sh
@@ -24,11 +24,12 @@ rm -rf "$DETOX_ARTIFACTS"
 rm -f "$METRO_LOG" "$LOGCAT_LOG" /tmp/rent-e2e-entry-*.bundle /tmp/rent-e2e-metro-status.txt
 
 if [ "$APP_BUILD_TYPE" = "debug" ]; then
-  EXPO_PUBLIC_MOCK_MODE=true EXPO_PUBLIC_E2E_MODE=true CI=1 BROWSER=none \
-    ./node_modules/.bin/expo start \
-    --localhost \
+  EXPO_PUBLIC_MOCK_MODE=true EXPO_PUBLIC_E2E_MODE=true \
+    ./node_modules/.bin/metro serve \
+    --host 127.0.0.1 \
     --port 8081 \
-    --clear \
+    --reset-cache \
+    --config metro.config.js \
     >"$METRO_LOG" 2>&1 &
   METRO_PID=$!
 fi

--- a/mobile/scripts/e2e-android-test.sh
+++ b/mobile/scripts/e2e-android-test.sh
@@ -14,21 +14,21 @@ fi
 APP_APK="android/app/build/outputs/apk/$APP_BUILD_TYPE/app-$APP_BUILD_TYPE.apk"
 TEST_APK="android/app/build/outputs/apk/androidTest/$TEST_BUILD_TYPE/app-$TEST_BUILD_TYPE-androidTest.apk"
 APP_ID="$(node -p "require('./app.json').expo.android.package")"
+METRO_STATUS_URL="http://127.0.0.1:8081/status"
 BUNDLE_URLS="http://127.0.0.1:8081/.expo/.virtual-metro-entry.bundle?platform=android&dev=true&minify=false
 http://127.0.0.1:8081/node_modules/expo-router/entry.bundle?platform=android&dev=true&minify=false"
 METRO_PID=""
 LOGCAT_PID=""
 
 rm -rf "$DETOX_ARTIFACTS"
-rm -f "$METRO_LOG" "$LOGCAT_LOG" /tmp/rent-e2e-entry-*.bundle
+rm -f "$METRO_LOG" "$LOGCAT_LOG" /tmp/rent-e2e-entry-*.bundle /tmp/rent-e2e-metro-status.txt
 
 if [ "$APP_BUILD_TYPE" = "debug" ]; then
-  EXPO_PUBLIC_MOCK_MODE=true EXPO_PUBLIC_E2E_MODE=true \
-    ./node_modules/.bin/metro serve \
-    --host 127.0.0.1 \
+  EXPO_PUBLIC_MOCK_MODE=true EXPO_PUBLIC_E2E_MODE=true CI=1 \
+    ./node_modules/.bin/expo start \
+    --localhost \
     --port 8081 \
-    --reset-cache \
-    --config metro.config.js \
+    --clear \
     >"$METRO_LOG" 2>&1 &
   METRO_PID=$!
 fi
@@ -44,6 +44,27 @@ cleanup() {
 trap cleanup EXIT
 
 if [ "$APP_BUILD_TYPE" = "debug" ]; then
+  STATUS_OUT="/tmp/rent-e2e-metro-status.txt"
+  for _ in $(seq 1 150); do
+    HTTP_CODE="$(curl -sS -o "$STATUS_OUT" -w '%{http_code}' "$METRO_STATUS_URL" 2>/dev/null || true)"
+    if [ "$HTTP_CODE" = "200" ] && grep -q "packager-status:running" "$STATUS_OUT"; then
+      break
+    fi
+    sleep 2
+  done
+
+  HTTP_CODE="$(curl -sS -o "$STATUS_OUT" -w '%{http_code}' "$METRO_STATUS_URL" 2>/dev/null || true)"
+  if [ "$HTTP_CODE" != "200" ] || ! grep -q "packager-status:running" "$STATUS_OUT"; then
+    echo "Expo Metro did not expose the React Native packager status within 5 minutes"
+    echo "Status URL: $METRO_STATUS_URL"
+    echo "Last HTTP status: $HTTP_CODE"
+    cat "$METRO_LOG"
+    if [ -s "$STATUS_OUT" ]; then
+      cat "$STATUS_OUT"
+    fi
+    exit 1
+  fi
+
   ENTRY_INDEX=1
   for BUNDLE_URL in $BUNDLE_URLS; do
     BUNDLE_OUT="/tmp/rent-e2e-entry-$ENTRY_INDEX.bundle"

--- a/mobile/scripts/e2e-android-test.sh
+++ b/mobile/scripts/e2e-android-test.sh
@@ -70,6 +70,16 @@ if [ "$APP_BUILD_TYPE" = "debug" ]; then
 fi
 
 adb wait-for-device
+if [ "$APP_BUILD_TYPE" = "debug" ]; then
+  adb reverse tcp:8081 tcp:8081
+  if ! adb reverse --list | grep -q "tcp:8081 tcp:8081"; then
+    echo "Failed to configure adb reverse for Metro on tcp:8081"
+    echo "Current adb reverse mappings:"
+    adb reverse --list || true
+    exit 1
+  fi
+fi
+
 adb install -r -d -g "$APP_APK"
 adb install -r -d "$TEST_APK"
 adb shell cmd package compile -m speed -f "$APP_ID" >/dev/null 2>&1 || true


### PR DESCRIPTION
This pull request introduces support for sending WhatsApp template messages throughout the payments and property visits flows, replacing the previous plain text message implementation. It also extends the WhatsApp message DTO and validation logic to handle new template-related fields, and updates all relevant tests to cover the new behavior.

**WhatsApp Template Messaging Integration**

* Payments and property visits now use `sendTemplateMessage` instead of `sendTextMessage`, passing template name, language, parameters, and context for richer, localized notifications. (`backend/src/payments/payments.service.ts` [[1]](diffhunk://#diff-ac79ce847a5f39bb5b449cb541c83dc227ad27cf0c724665da39154094e3ce84R279-R294) [[2]](diffhunk://#diff-ac79ce847a5f39bb5b449cb541c83dc227ad27cf0c724665da39154094e3ce84R635-R646) [[3]](diffhunk://#diff-ac79ce847a5f39bb5b449cb541c83dc227ad27cf0c724665da39154094e3ce84R697-R729); `backend/src/properties/property-visits.service.ts` [[4]](diffhunk://#diff-90768ce2271ccf74bc6f9db5a353e83eb2a4c7a38e4704d155b9074922d54b59L69-R97) [[5]](diffhunk://#diff-90768ce2271ccf74bc6f9db5a353e83eb2a4c7a38e4704d155b9074922d54b59L259-R288) [[6]](diffhunk://#diff-90768ce2271ccf74bc6f9db5a353e83eb2a4c7a38e4704d155b9074922d54b59R361-R388) [[7]](diffhunk://#diff-90768ce2271ccf74bc6f9db5a353e83eb2a4c7a38e4704d155b9074922d54b59R404-R423)

* New helper methods and context objects are introduced to build template parameters and pass additional metadata (such as company, entity, and activity IDs) with each notification. (`backend/src/properties/property-visits.service.ts` [[1]](diffhunk://#diff-90768ce2271ccf74bc6f9db5a353e83eb2a4c7a38e4704d155b9074922d54b59R34-R41) [[2]](diffhunk://#diff-90768ce2271ccf74bc6f9db5a353e83eb2a4c7a38e4704d155b9074922d54b59R361-R388)

**DTO and Validation Enhancements**

* The `SendWhatsappMessageDto` and its Zod schema now support template-specific fields: `templateName`, `templateLanguage`, `templateParameters`, and additional context fields like `activityEntity`, `activityId`, `relatedEntityType`, `relatedEntityId`, and `companyId`. (`backend/src/whatsapp/dto/send-whatsapp-message.dto.ts` [[1]](diffhunk://#diff-e47b3023b79a6feebe37b1760bec07a58eac54ddd006aa07cdf855f07022d345R2-R6) [[2]](diffhunk://#diff-e47b3023b79a6feebe37b1760bec07a58eac54ddd006aa07cdf855f07022d345R26-R51) [[3]](diffhunk://#diff-e47b3023b79a6feebe37b1760bec07a58eac54ddd006aa07cdf855f07022d345R73-R123)

**Test Suite Updates**

* All relevant service and controller tests are updated to use `sendTemplateMessage`, including proper mocking and assertion of the new template parameters and context. (`backend/src/payments/payments.service.spec.ts` [[1]](diffhunk://#diff-142ff14564cc0aec09e4896da8b081495526714637d5c2abcaa7b47b0da2e94bL76-R79) [[2]](diffhunk://#diff-142ff14564cc0aec09e4896da8b081495526714637d5c2abcaa7b47b0da2e94bL616-R619) [[3]](diffhunk://#diff-142ff14564cc0aec09e4896da8b081495526714637d5c2abcaa7b47b0da2e94bL629-R645) [[4]](diffhunk://#diff-142ff14564cc0aec09e4896da8b081495526714637d5c2abcaa7b47b0da2e94bL672-R685); `backend/src/properties/property-visits.service.spec.ts` [[5]](diffhunk://#diff-5d7d33c2fc3cdbd2285b6fd3d5b227c18175ba4a1a3ca31b117c06228b9c398bL27-R27) [[6]](diffhunk://#diff-5d7d33c2fc3cdbd2285b6fd3d5b227c18175ba4a1a3ca31b117c06228b9c398bL42-R42) [[7]](diffhunk://#diff-5d7d33c2fc3cdbd2285b6fd3d5b227c18175ba4a1a3ca31b117c06228b9c398bL125-R140) [[8]](diffhunk://#diff-5d7d33c2fc3cdbd2285b6fd3d5b227c18175ba4a1a3ca31b117c06228b9c398bL220-R235) [[9]](diffhunk://#diff-5d7d33c2fc3cdbd2285b6fd3d5b227c18175ba4a1a3ca31b117c06228b9c398bL416-R431) [[10]](diffhunk://#diff-5d7d33c2fc3cdbd2285b6fd3d5b227c18175ba4a1a3ca31b117c06228b9c398bL432-R447); `backend/src/whatsapp/whatsapp.controller.spec.ts` [[11]](diffhunk://#diff-914f5685cf5ab51284cd5d7f9ff40d35e8e1865f177393c35c38ab17007f9858R8) [[12]](diffhunk://#diff-914f5685cf5ab51284cd5d7f9ff40d35e8e1865f177393c35c38ab17007f9858R40-R46) [[13]](diffhunk://#diff-914f5685cf5ab51284cd5d7f9ff40d35e8e1865f177393c35c38ab17007f9858R64-R104) [[14]](diffhunk://#diff-914f5685cf5ab51284cd5d7f9ff40d35e8e1865f177393c35c38ab17007f9858L151-R204)

These changes lay the groundwork for richer, more structured WhatsApp notifications, enabling better localization and tracking of messages related to payments and property visits.