### PR TITLE
Harden MercadoPago webhooks and migration checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,9 @@ STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret_here
 # MercadoPago (Test Mode)
 MERCADOPAGO_PUBLIC_KEY=TEST-your_public_key_here
 MERCADOPAGO_ACCESS_TOKEN=TEST-your_access_token_here
+MERCADOPAGO_WEBHOOK_SECRET=your_webhook_signature_secret_here
+# Ventana máxima aceptada para la firma del webhook (segundos)
+MERCADOPAGO_WEBHOOK_TOLERANCE_SECONDS=300
 # URL pública del backend (usada para webhook de MercadoPago)
 APP_URL=https://your-backend-domain.com
 

--- a/backend/src/payment-gateway/payment-gateway.controller.ts
+++ b/backend/src/payment-gateway/payment-gateway.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Get,
+  Headers,
   HttpCode,
   HttpStatus,
   Param,
@@ -17,7 +18,6 @@ import { Public } from '../common/decorators/public.decorator';
 import { UserRole } from '../users/entities/user.entity';
 import { PaymentGatewayService } from './payment-gateway.service';
 import { CreatePaymentPreferenceDto } from './dto/create-payment-preference.dto';
-import { WebhookNotificationDto } from './dto/webhook-notification.dto';
 import { PaymentGatewayTransaction } from './entities/payment-gateway-transaction.entity';
 
 interface AuthenticatedRequest {
@@ -74,8 +74,16 @@ export class PaymentGatewayController {
   @Public()
   @HttpCode(HttpStatus.OK)
   async processWebhook(
-    @Body() notification: WebhookNotificationDto,
+    @Body() notification: unknown,
+    @Headers('x-signature') xSignature?: string,
+    @Headers('x-request-id') xRequestId?: string,
+    @Query('data.id') dottedDataId?: string,
+    @Query('data_id') underscoredDataId?: string,
   ): Promise<void> {
-    return this.paymentGatewayService.processWebhook(notification);
+    return this.paymentGatewayService.processWebhook(notification, {
+      xSignature,
+      xRequestId,
+      dataId: dottedDataId ?? underscoredDataId,
+    });
   }
 }

--- a/backend/src/payment-gateway/payment-gateway.service.spec.ts
+++ b/backend/src/payment-gateway/payment-gateway.service.spec.ts
@@ -1,7 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { createHmac } from 'node:crypto';
 import {
+  BadRequestException,
   NotFoundException,
   InternalServerErrorException,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
@@ -260,6 +263,102 @@ describe('PaymentGatewayService', () => {
 
       expect(txRepo.update).not.toHaveBeenCalled();
       expect(dataSource.query).not.toHaveBeenCalled();
+    });
+
+    it('should accept a valid signed notification with numeric ids', async () => {
+      const receivedAt = 1_754_000_000_000;
+      const timestamp = String(receivedAt);
+      const requestId = 'request-123';
+      const dataId = '456';
+      const secret = 'webhook-secret';
+      const digest = createHmac('sha256', secret)
+        .update(`id:${dataId};request-id:${requestId};ts:${timestamp};`)
+        .digest('hex');
+
+      configService.get.mockImplementation((key: string) => {
+        if (key === 'MERCADOPAGO_WEBHOOK_SECRET') return secret;
+        if (key === 'MERCADOPAGO_ACCESS_TOKEN') return 'TEST_TOKEN';
+        return undefined;
+      });
+      httpService.get.mockReturnValue(
+        of({
+          data: {
+            id: dataId,
+            status: 'approved',
+            external_reference: 'invoice-uuid-1234',
+          },
+        } as AxiosResponse),
+      );
+      txRepo.findOne!.mockResolvedValue(null);
+
+      await service.processWebhook(
+        {
+          id: 123,
+          live_mode: true,
+          type: 'payment',
+          data: { id: 456 },
+        },
+        {
+          xSignature: `ts=${timestamp},v1=${digest}`,
+          xRequestId: requestId,
+          dataId,
+          receivedAt,
+        },
+      );
+
+      expect(httpService.get).toHaveBeenCalledWith(
+        `https://api.mercadopago.com/v1/payments/${dataId}`,
+        expect.any(Object),
+      );
+    });
+
+    it('should reject an invalid webhook signature', async () => {
+      configService.get.mockImplementation((key: string) => {
+        if (key === 'MERCADOPAGO_WEBHOOK_SECRET') return 'webhook-secret';
+        return undefined;
+      });
+
+      await expect(
+        service.processWebhook(baseNotification, {
+          xSignature: 'ts=1754000000000,v1=deadbeef',
+          xRequestId: 'request-123',
+          dataId: baseNotification.data.id,
+          receivedAt: 1_754_000_000_000,
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+      expect(httpService.get).not.toHaveBeenCalled();
+    });
+
+    it('should reject a signed query id that differs from the payload id', async () => {
+      configService.get.mockImplementation((key: string) => {
+        if (key === 'MERCADOPAGO_WEBHOOK_SECRET') return 'webhook-secret';
+        return undefined;
+      });
+
+      await expect(
+        service.processWebhook(baseNotification, {
+          xSignature: 'ts=1754000000000,v1=deadbeef',
+          dataId: 'different-payment-id',
+          receivedAt: 1_754_000_000_000,
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should reject malformed webhook payloads', async () => {
+      await expect(service.processWebhook({ type: 'payment' })).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should require a webhook secret in production', async () => {
+      configService.get.mockImplementation((key: string) => {
+        if (key === 'NODE_ENV') return 'production';
+        return undefined;
+      });
+
+      await expect(service.processWebhook(baseNotification)).rejects.toThrow(
+        InternalServerErrorException,
+      );
     });
   });
 

--- a/backend/src/payment-gateway/payment-gateway.service.ts
+++ b/backend/src/payment-gateway/payment-gateway.service.ts
@@ -1,9 +1,12 @@
 import {
+  BadRequestException,
   Injectable,
   NotFoundException,
   ForbiddenException,
   InternalServerErrorException,
+  UnauthorizedException,
 } from '@nestjs/common';
+import { createHmac, timingSafeEqual } from 'node:crypto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
@@ -17,7 +20,21 @@ import { Invoice, InvoiceStatus } from '../payments/entities/invoice.entity';
 import { Tenant } from '../tenants/entities/tenant.entity';
 import { UserRole } from '../users/entities/user.entity';
 import { CreatePaymentPreferenceDto } from './dto/create-payment-preference.dto';
-import { WebhookNotificationDto } from './dto/webhook-notification.dto';
+
+interface MercadoPagoWebhookNotification {
+  id: string;
+  type: string;
+  data: { id: string };
+  action?: string;
+  date_created?: string;
+}
+
+export interface MercadoPagoWebhookSignatureContext {
+  xSignature?: string;
+  xRequestId?: string;
+  dataId?: string;
+  receivedAt?: number;
+}
 
 interface UserContext {
   id: string;
@@ -143,7 +160,13 @@ export class PaymentGatewayService {
     };
   }
 
-  async processWebhook(notification: WebhookNotificationDto): Promise<void> {
+  async processWebhook(
+    payload: unknown,
+    signatureContext: MercadoPagoWebhookSignatureContext = {},
+  ): Promise<void> {
+    const notification = this.normalizeWebhookNotification(payload);
+    this.validateWebhookSignature(notification, signatureContext);
+
     if (notification.type !== 'payment') {
       return;
     }
@@ -206,6 +229,125 @@ export class PaymentGatewayService {
         `UPDATE invoices SET status = $1, updated_at = NOW() WHERE id = $2 AND company_id = $3`,
         [InvoiceStatus.PAID, invoiceId, tx.companyId],
       );
+    }
+  }
+
+  private normalizeWebhookNotification(
+    payload: unknown,
+  ): MercadoPagoWebhookNotification {
+    if (!payload || typeof payload !== 'object') {
+      throw new BadRequestException('Invalid MercadoPago webhook payload');
+    }
+
+    const candidate = payload as Record<string, unknown>;
+    const data = candidate.data;
+    if (!data || typeof data !== 'object') {
+      throw new BadRequestException('MercadoPago webhook data is required');
+    }
+
+    const dataId = (data as Record<string, unknown>).id;
+    if (
+      (typeof dataId !== 'string' && typeof dataId !== 'number') ||
+      (typeof candidate.type !== 'string' &&
+        typeof candidate.topic !== 'string')
+    ) {
+      throw new BadRequestException('Invalid MercadoPago webhook payload');
+    }
+
+    const rawNotificationId = candidate.id;
+    const notificationId =
+      typeof rawNotificationId === 'string' ||
+      typeof rawNotificationId === 'number'
+        ? String(rawNotificationId)
+        : String(dataId);
+
+    return {
+      id: notificationId,
+      type: String(candidate.type ?? candidate.topic),
+      data: { id: String(dataId) },
+      ...(typeof candidate.action === 'string'
+        ? { action: candidate.action }
+        : {}),
+      ...(typeof candidate.date_created === 'string'
+        ? { date_created: candidate.date_created }
+        : {}),
+    };
+  }
+
+  private validateWebhookSignature(
+    notification: MercadoPagoWebhookNotification,
+    context: MercadoPagoWebhookSignatureContext,
+  ): void {
+    const secret = this.configService.get<string>('MERCADOPAGO_WEBHOOK_SECRET');
+    const isProduction =
+      this.configService.get<string>('NODE_ENV') === 'production';
+
+    if (!secret) {
+      if (isProduction) {
+        throw new InternalServerErrorException(
+          'MercadoPago webhook secret is not configured',
+        );
+      }
+      return;
+    }
+
+    const signedDataId = context.dataId ?? notification.data.id;
+    if (
+      context.dataId &&
+      context.dataId.toLowerCase() !== notification.data.id.toLowerCase()
+    ) {
+      throw new UnauthorizedException('Invalid MercadoPago webhook signature');
+    }
+
+    const signatureParts = new Map(
+      (context.xSignature ?? '').split(',').map((part) => {
+        const separator = part.indexOf('=');
+        if (separator < 1) return ['', ''];
+        return [part.slice(0, separator).trim(), part.slice(separator + 1)];
+      }),
+    );
+    const timestamp = signatureParts.get('ts');
+    const providedDigest = signatureParts.get('v1');
+
+    if (!timestamp || !providedDigest) {
+      throw new UnauthorizedException('Invalid MercadoPago webhook signature');
+    }
+
+    const signatureTemplate = [
+      `id:${signedDataId.toLowerCase()};`,
+      context.xRequestId ? `request-id:${context.xRequestId};` : '',
+      `ts:${timestamp};`,
+    ].join('');
+    const expectedDigest = createHmac('sha256', secret)
+      .update(signatureTemplate)
+      .digest('hex');
+    const providedBuffer = Buffer.from(providedDigest, 'hex');
+    const expectedBuffer = Buffer.from(expectedDigest, 'hex');
+
+    if (
+      providedBuffer.length !== expectedBuffer.length ||
+      !timingSafeEqual(providedBuffer, expectedBuffer)
+    ) {
+      throw new UnauthorizedException('Invalid MercadoPago webhook signature');
+    }
+
+    const timestampValue = Number(timestamp);
+    const timestampMs =
+      timestampValue < 1_000_000_000_000
+        ? timestampValue * 1000
+        : timestampValue;
+    const toleranceSeconds = Number(
+      this.configService.get<string>('MERCADOPAGO_WEBHOOK_TOLERANCE_SECONDS') ??
+        300,
+    );
+    const receivedAt = context.receivedAt ?? Date.now();
+
+    if (
+      !Number.isFinite(timestampMs) ||
+      !Number.isFinite(toleranceSeconds) ||
+      Math.abs(receivedAt - timestampMs) > toleranceSeconds * 1000
+    ) {
+      throw new UnauthorizedException('Expired MercadoPago webhook signature');
     }
   }
 

--- a/backend/test/payment-gateway.e2e-spec.ts
+++ b/backend/test/payment-gateway.e2e-spec.ts
@@ -1,0 +1,74 @@
+import { createHmac } from 'node:crypto';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { AppModule } from './../src/app.module';
+
+describe('MercadoPago webhook (e2e)', () => {
+  let app: INestApplication;
+  const webhookSecret = 'e2e-mercadopago-webhook-secret';
+  const originalSecret = process.env.MERCADOPAGO_WEBHOOK_SECRET;
+
+  beforeAll(async () => {
+    process.env.MERCADOPAGO_WEBHOOK_SECRET = webhookSecret;
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    if (originalSecret === undefined) {
+      delete process.env.MERCADOPAGO_WEBHOOK_SECRET;
+    } else {
+      process.env.MERCADOPAGO_WEBHOOK_SECRET = originalSecret;
+    }
+  });
+
+  const signatureFor = (dataId: string, requestId: string, timestamp: string) =>
+    createHmac('sha256', webhookSecret)
+      .update(`id:${dataId};request-id:${requestId};ts:${timestamp};`)
+      .digest('hex');
+
+  it('accepts a valid signed notification with provider metadata', async () => {
+    const dataId = '456';
+    const requestId = 'e2e-request-1';
+    const timestamp = String(Date.now());
+    const digest = signatureFor(dataId, requestId, timestamp);
+
+    await request(app.getHttpServer())
+      .post('/payment-gateway/webhook')
+      .query({ 'data.id': dataId })
+      .set('x-request-id', requestId)
+      .set('x-signature', `ts=${timestamp},v1=${digest}`)
+      .send({
+        id: 123,
+        live_mode: false,
+        type: 'merchant_order',
+        api_version: 'v1',
+        action: 'merchant_order.updated',
+        data: { id: Number(dataId) },
+      })
+      .expect(200);
+  });
+
+  it('rejects a notification with an invalid signature', async () => {
+    const timestamp = String(Date.now());
+
+    await request(app.getHttpServer())
+      .post('/payment-gateway/webhook')
+      .query({ 'data.id': '456' })
+      .set('x-request-id', 'e2e-request-2')
+      .set('x-signature', `ts=${timestamp},v1=${'0'.repeat(64)}`)
+      .send({
+        id: 124,
+        type: 'merchant_order',
+        data: { id: 456 },
+      })
+      .expect(401);
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,9 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-rent_dev}
       POSTGRES_USER: ${POSTGRES_USER:-rent_user}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-rent_dev_password}
-      POSTGRES_INITDB_ARGS: "--encoding=UTF8 --locale=es_ES.UTF-8"
+      # The Alpine-based PostGIS image guarantees C.UTF-8; es_ES.UTF-8 is not
+      # installed and leaves PostgreSQL in a restart loop after initialization.
+      POSTGRES_INITDB_ARGS: "--encoding=UTF8 --locale=C.UTF-8"
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:

--- a/docs/plan-de-trabajo.md
+++ b/docs/plan-de-trabajo.md
@@ -282,10 +282,10 @@ Integrar servicios externos críticos para el negocio.
   - Webhooks de confirmación
   - Manejo de errores y reintentos
 
-- **T213**: Integración con MercadoPago
+- 🔄 **T213**: Integración con MercadoPago (EN PROGRESO)
   - Implementación de Strategy para MP
-  - Checkout Pro
-  - Webhooks IPN
+  - ✅ Checkout Pro
+  - ✅ Webhooks con validación HMAC e idempotencia de transacción
   - Testing en sandbox
 
 - ✅ **T214**: API de Pagos
@@ -704,10 +704,10 @@ Implementar sistema de cobranza multicanal y liquidación a propietarios.
 
 ### 8.2 Integración MercadoPago
 
-- **T821**: Servicio MercadoPago
-  - MercadoPagoService
-  - Crear preferencia de pago
-  - Webhooks IPN
+- 🔄 **T821**: Servicio MercadoPago (EN PROGRESO)
+  - ✅ PaymentGatewayService
+  - ✅ Crear preferencia de pago
+  - ✅ Webhooks con validación de origen
   - Testing sandbox
 
 - **T822**: Link de pago en facturas

--- a/docs/technical/payments.md
+++ b/docs/technical/payments.md
@@ -1,0 +1,72 @@
+# Pagos, cobranzas y liquidaciones
+
+## Alcance actual
+
+El dominio de pagos conecta facturas, cuentas corrientes, pagos, recibos y
+liquidaciones. MercadoPago Checkout Pro está implementado en
+`backend/src/payment-gateway`; las transferencias y cripto permanecen como
+pendientes del plan de trabajo.
+
+## Flujo MercadoPago
+
+1. Un administrador o inquilino autenticado crea una preferencia con
+   `POST /payment-gateway/preferences` indicando el UUID de la factura.
+2. El backend verifica que la factura pertenezca a la empresa y, para un
+   inquilino, a su propia cuenta.
+3. MercadoPago devuelve las URLs de Checkout Pro y el backend registra una
+   transacción `pending` en `payment_gateway_transactions`.
+4. MercadoPago envía eventos a `POST /payment-gateway/webhook`.
+5. El backend valida la firma HMAC, consulta el pago en la API de MercadoPago y
+   actualiza la transacción. Los reintentos sobre una transacción ya procesada
+   no vuelven a aplicar el cambio.
+
+## Configuración
+
+Variables requeridas en producción:
+
+```dotenv
+MERCADOPAGO_ACCESS_TOKEN=...
+MERCADOPAGO_WEBHOOK_SECRET=...
+MERCADOPAGO_WEBHOOK_TOLERANCE_SECONDS=300
+APP_URL=https://rent.example.com/api
+```
+
+La clave de webhook se obtiene en MercadoPago Developers, dentro de la
+aplicación, en `Webhooks > Configurar notificaciones`. Debe guardarse únicamente
+en el archivo de secretos del ambiente.
+
+Referencia oficial: [Configurar notificaciones de pago](https://www.mercadopago.com.ar/developers/es/docs/checkout-pro/payment-notifications).
+
+El webhook usa los encabezados `x-signature` y `x-request-id` y el query param
+`data.id` (también se acepta `data_id` por compatibilidad). En producción el
+backend rechaza la notificación si falta la clave configurada, la firma no
+coincide, el identificador firmado difiere del cuerpo o el timestamp excede la
+tolerancia.
+
+## Migraciones
+
+La tabla de transacciones de la pasarela se crea en
+`migrations/079_add_payment_gateway_transactions.sql`. Toda modificación futura
+del contrato persistido debe agregarse como una migración numerada nueva; las
+migraciones existentes no se editan después de haber sido desplegadas.
+
+Validación local de la cadena completa:
+
+```bash
+./migrations/run-migrations.sh
+cd backend
+npm run test:e2e -- --runInBand payment-gateway.e2e-spec.ts
+```
+
+## Salida a producción
+
+Antes de habilitar el checkout:
+
+1. Configurar credenciales productivas y la firma secreta.
+2. Registrar el webhook HTTPS de producción para eventos de pagos.
+3. Ejecutar un pago controlado y verificar la transición de la transacción.
+4. Confirmar que no se creen efectos duplicados al reenviar el mismo evento.
+5. Verificar healthcheck y logs del backend después del despliegue.
+
+La prueba real de sandbox y el cierre automático del circuito contable siguen
+siendo requisitos para marcar `T213/T821` como completadas.

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -45,6 +45,21 @@ POSTGRES_PASSWORD
 POSTGRES_DB
 ```
 
+Para una base temporal o CI se puede conservar el entorno ya exportado sin
+cargar el `.env` local:
+
+```bash
+MIGRATIONS_SKIP_ENV_FILE=true \
+POSTGRES_HOST=localhost POSTGRES_PORT=55432 \
+POSTGRES_USER=test POSTGRES_PASSWORD=test POSTGRES_DB=rent_test \
+./migrations/run-migrations.sh --status
+```
+
+También se puede indicar otro archivo con `MIGRATIONS_ENV_FILE=/ruta/al/.env`.
+Si no hay un cliente `psql` local, `MIGRATIONS_CONTAINER_NAME` selecciona el
+contenedor PostgreSQL donde se ejecutarán las consultas (por defecto,
+`rent-postgres`).
+
 ## Crear Una Migración
 
 1. Buscar el último número:

--- a/migrations/run-migrations.sh
+++ b/migrations/run-migrations.sh
@@ -20,7 +20,11 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Cargar variables de entorno
 load_env_file() {
-    local env_file="$PROJECT_ROOT/.env"
+    if [ "${MIGRATIONS_SKIP_ENV_FILE:-false}" = true ]; then
+        return 0
+    fi
+
+    local env_file="${MIGRATIONS_ENV_FILE:-$PROJECT_ROOT/.env}"
 
     if [ ! -f "$env_file" ]; then
         return 0
@@ -82,7 +86,7 @@ print_info() {
 
 # Determine execution method
 declare -a EXEC_CMD=()
-CONTAINER_NAME="rent-postgres"
+CONTAINER_NAME="${MIGRATIONS_CONTAINER_NAME:-rent-postgres}"
 
 run_query() {
     local sql="$1"

--- a/scripts/reset-db.sh
+++ b/scripts/reset-db.sh
@@ -122,7 +122,7 @@ create_database() {
     print_info "Creando base de datos nueva..."
     
     # Crear base de datos
-    docker exec -it "$CONTAINER_NAME" psql -U "$POSTGRES_USER" -c "CREATE DATABASE $POSTGRES_DB WITH ENCODING='UTF8' LC_COLLATE='es_ES.UTF-8' LC_CTYPE='es_ES.UTF-8';" 2>/dev/null
+    docker exec -it "$CONTAINER_NAME" psql -U "$POSTGRES_USER" -c "CREATE DATABASE $POSTGRES_DB WITH ENCODING='UTF8' LC_COLLATE='C.UTF-8' LC_CTYPE='C.UTF-8';" 2>/dev/null
     
     print_success "Base de datos creada"
 }


### PR DESCRIPTION
## Qué cambia

- valida webhooks de MercadoPago con HMAC, comparación segura, tolerancia temporal y consistencia del payment ID
- acepta el payload real del proveedor sin perder la validación de estructura
- agrega unit tests y E2E del endpoint firmado
- corrige el locale PostgreSQL portable para entornos nuevos
- permite ejecutar migraciones contra archivos o contenedores temporales sin cargar el .env local
- documenta configuración y refleja T213/T821 como en progreso

## Motivo

El webhook aceptaba notificaciones sin validar su origen y su DTO rechazaba campos e IDs válidos del proveedor. Además, la imagen Alpine no contiene es_ES.UTF-8, lo que dejaba PostgreSQL en restart loop.

## Validación

- backend: 109 suites / 853 tests; cobertura 91.24% statements, 74.9% branches, 82.83% functions, 91.97% lines
- backend E2E: 8 suites / 52 tests
- migraciones 060-090 baselined y 091 aplicada en PostgreSQL temporal con pgvector
- type-check, format, build, bash syntax y docker compose config verdes

## Pendiente externo

La prueba real en sandbox de MercadoPago sigue pendiente de credenciales; por eso T213/T821 no se marcan completas.