### PR TITLE
feat(bank-accounts): add virtual alias foundation

### DIFF
--- a/backend/src/bank-accounts/bank-accounts.module.ts
+++ b/backend/src/bank-accounts/bank-accounts.module.ts
@@ -4,9 +4,11 @@ import { BankAccount } from './entities/bank-account.entity';
 import { Owner } from '../owners/entities/owner.entity';
 import { BankAccountsService } from './bank-accounts.service';
 import { BankAccountsController } from './bank-accounts.controller';
+import { Property } from '../properties/entities/property.entity';
+import { User } from '../users/entities/user.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([BankAccount, Owner])],
+  imports: [TypeOrmModule.forFeature([BankAccount, Owner, Property, User])],
   controllers: [BankAccountsController],
   providers: [BankAccountsService],
   exports: [TypeOrmModule, BankAccountsService],

--- a/backend/src/bank-accounts/bank-accounts.service.spec.ts
+++ b/backend/src/bank-accounts/bank-accounts.service.spec.ts
@@ -14,6 +14,12 @@ describe('BankAccountsService', () => {
   const ownersRepository = {
     findOne: jest.fn(),
   };
+  const propertiesRepository = {
+    findOne: jest.fn(),
+  };
+  const usersRepository = {
+    findOne: jest.fn(),
+  };
 
   let service: BankAccountsService;
 
@@ -30,9 +36,12 @@ describe('BankAccountsService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    usersRepository.findOne.mockResolvedValue({ id: 'u1', companyId: 'c1' });
     service = new BankAccountsService(
       bankAccountsRepository as any,
       ownersRepository as any,
+      propertiesRepository as any,
+      usersRepository as any,
     );
   });
 
@@ -149,6 +158,7 @@ describe('BankAccountsService', () => {
 
     it('creates for OWNER using resolved owner id', async () => {
       ownersRepository.findOne.mockResolvedValue({ id: 'o1' });
+      usersRepository.findOne.mockResolvedValue({ id: 'u2', companyId: 'c1' });
       const dto = { bankName: 'B', accountNumber: '1' };
       bankAccountsRepository.create.mockReturnValue({
         id: 'ba3',
@@ -160,12 +170,130 @@ describe('BankAccountsService', () => {
       });
       const result = await service.create(dto as any, 'c1', ownerUser);
       expect(result.ownerId).toBe('o1');
+      expect(bankAccountsRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'u2', ownerId: 'o1' }),
+      );
     });
 
     it('throws ForbiddenException when OWNER has no owner profile on create', async () => {
       ownersRepository.findOne.mockResolvedValue(null);
       await expect(
         service.create({ bankName: 'B' } as any, 'c1', ownerUser),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('creates a virtual alias associated with a company property', async () => {
+      ownersRepository.findOne.mockResolvedValue({ id: 'o1' });
+      propertiesRepository.findOne.mockResolvedValue({
+        id: 'p1',
+        companyId: 'c1',
+        ownerId: 'o1',
+      });
+      const dto = {
+        bankName: 'Virtual Bank',
+        accountType: 'virtual',
+        accountNumber: 'VA-1',
+        ownerId: 'o1',
+        propertyId: 'p1',
+        alias: 'rent.unit.1',
+        isVirtualAlias: true,
+      };
+      bankAccountsRepository.create.mockReturnValue({ id: 'ba4', ...dto });
+      bankAccountsRepository.save.mockResolvedValue({ id: 'ba4', ...dto });
+
+      await expect(
+        service.create(dto as any, 'c1', adminUser),
+      ).resolves.toEqual(
+        expect.objectContaining({ alias: 'rent.unit.1', propertyId: 'p1' }),
+      );
+    });
+
+    it('rejects virtual aliases without a property and alias', async () => {
+      await expect(
+        service.create(
+          {
+            bankName: 'Virtual Bank',
+            accountType: 'virtual',
+            accountNumber: 'VA-1',
+            isVirtualAlias: true,
+          } as any,
+          'c1',
+          adminUser,
+        ),
+      ).rejects.toThrow('Virtual bank accounts require propertyId and alias');
+    });
+
+    it('rejects a referenced user from another company', async () => {
+      usersRepository.findOne.mockResolvedValue(null);
+      await expect(
+        service.create(
+          {
+            bankName: 'Bank',
+            accountType: 'checking',
+            accountNumber: '1',
+            userId: 'foreign-user',
+          } as any,
+          'c1',
+          adminUser,
+        ),
+      ).rejects.toThrow('Bank account user must belong to company');
+    });
+
+    it('rejects an owner from another company', async () => {
+      ownersRepository.findOne.mockResolvedValue(null);
+      await expect(
+        service.create(
+          {
+            bankName: 'Bank',
+            accountType: 'checking',
+            accountNumber: '1',
+            ownerId: 'foreign-owner',
+          } as any,
+          'c1',
+          adminUser,
+        ),
+      ).rejects.toThrow('Bank account owner must belong to company');
+    });
+
+    it('rejects a virtual alias property from another company', async () => {
+      propertiesRepository.findOne.mockResolvedValue(null);
+      await expect(
+        service.create(
+          {
+            bankName: 'Virtual Bank',
+            accountType: 'virtual',
+            accountNumber: 'VA-1',
+            propertyId: 'foreign-property',
+            alias: 'rent.foreign',
+            isVirtualAlias: true,
+          } as any,
+          'c1',
+          adminUser,
+        ),
+      ).rejects.toThrow('Virtual alias property must belong to company');
+    });
+
+    it('prevents owners from assigning aliases to another owner property', async () => {
+      ownersRepository.findOne.mockResolvedValue({ id: 'o1' });
+      usersRepository.findOne.mockResolvedValue({ id: 'u2', companyId: 'c1' });
+      propertiesRepository.findOne.mockResolvedValue({
+        id: 'p2',
+        companyId: 'c1',
+        ownerId: 'other-owner',
+      });
+      await expect(
+        service.create(
+          {
+            bankName: 'Virtual Bank',
+            accountType: 'virtual',
+            accountNumber: 'VA-2',
+            propertyId: 'p2',
+            alias: 'rent.other',
+            isVirtualAlias: true,
+          } as any,
+          'c1',
+          ownerUser,
+        ),
       ).rejects.toThrow(ForbiddenException);
     });
   });

--- a/backend/src/bank-accounts/bank-accounts.service.ts
+++ b/backend/src/bank-accounts/bank-accounts.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Injectable,
   ForbiddenException,
   NotFoundException,
@@ -10,6 +11,8 @@ import { CreateBankAccountDto } from './dto/create-bank-account.dto';
 import { UpdateBankAccountDto } from './dto/update-bank-account.dto';
 import { UserRole } from '../users/entities/user.entity';
 import { Owner } from '../owners/entities/owner.entity';
+import { Property } from '../properties/entities/property.entity';
+import { User } from '../users/entities/user.entity';
 
 interface UserContext {
   id: string;
@@ -24,6 +27,10 @@ export class BankAccountsService {
     private readonly bankAccountsRepository: Repository<BankAccount>,
     @InjectRepository(Owner)
     private readonly ownersRepository: Repository<Owner>,
+    @InjectRepository(Property)
+    private readonly propertiesRepository: Repository<Property>,
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
   ) {}
 
   async findAll(
@@ -89,6 +96,7 @@ export class BankAccountsService {
     user?: UserContext,
   ): Promise<BankAccount> {
     let ownerId = dto.ownerId ?? null;
+    let userId = dto.userId ?? null;
 
     if (user?.role === UserRole.OWNER) {
       const owner = await this.resolveOwnerForUser(user, companyId);
@@ -96,7 +104,17 @@ export class BankAccountsService {
         throw new ForbiddenException('Owner profile not found');
       }
       ownerId = owner.id;
+      userId = user.id;
     }
+
+    await this.validateReferences(
+      companyId,
+      user,
+      ownerId,
+      userId,
+      dto.propertyId ?? null,
+    );
+    this.validateVirtualAlias(dto);
 
     if (dto.isDefault) {
       await this.bankAccountsRepository.update(
@@ -109,6 +127,7 @@ export class BankAccountsService {
       companyId,
       currency: dto.currency ?? 'ARS',
       ownerId,
+      userId,
     });
     return this.bankAccountsRepository.save(account);
   }
@@ -120,6 +139,26 @@ export class BankAccountsService {
     user?: UserContext,
   ): Promise<BankAccount> {
     const account = await this.findOne(id, companyId, user);
+    const nextOwnerId =
+      user?.role === UserRole.OWNER
+        ? account.ownerId
+        : (dto.ownerId ?? account.ownerId);
+    const nextUserId =
+      user?.role === UserRole.OWNER ? user.id : (dto.userId ?? account.userId);
+    const nextPropertyId = dto.propertyId ?? account.propertyId;
+
+    await this.validateReferences(
+      companyId,
+      user,
+      nextOwnerId,
+      nextUserId,
+      nextPropertyId,
+    );
+    this.validateVirtualAlias({
+      isVirtualAlias: dto.isVirtualAlias ?? account.isVirtualAlias,
+      propertyId: nextPropertyId ?? undefined,
+      alias: dto.alias ?? account.alias ?? undefined,
+    });
 
     if (dto.isDefault) {
       await this.bankAccountsRepository.update(
@@ -128,8 +167,72 @@ export class BankAccountsService {
       );
     }
 
-    Object.assign(account, dto);
+    Object.assign(account, dto, {
+      ownerId: nextOwnerId,
+      userId: nextUserId,
+      propertyId: nextPropertyId,
+    });
     return this.bankAccountsRepository.save(account);
+  }
+
+  private async validateReferences(
+    companyId: string,
+    user: UserContext | undefined,
+    ownerId: string | null,
+    userId: string | null,
+    propertyId: string | null,
+  ): Promise<void> {
+    if (userId) {
+      const referencedUser = await this.usersRepository.findOne({
+        where: { id: userId, companyId },
+      });
+      if (!referencedUser) {
+        throw new BadRequestException(
+          'Bank account user must belong to company',
+        );
+      }
+    }
+
+    if (ownerId) {
+      const owner = await this.ownersRepository.findOne({
+        where: { id: ownerId, companyId },
+      });
+      if (!owner) {
+        throw new BadRequestException(
+          'Bank account owner must belong to company',
+        );
+      }
+    }
+
+    if (!propertyId) return;
+
+    const property = await this.propertiesRepository.findOne({
+      where: { id: propertyId, companyId },
+    });
+    if (!property) {
+      throw new BadRequestException(
+        'Virtual alias property must belong to company',
+      );
+    }
+    if (user?.role === UserRole.OWNER && property.ownerId !== ownerId) {
+      throw new ForbiddenException(
+        'You can only assign aliases to your own properties',
+      );
+    }
+  }
+
+  private validateVirtualAlias(
+    values: Pick<
+      CreateBankAccountDto,
+      'isVirtualAlias' | 'propertyId' | 'alias'
+    >,
+  ): void {
+    if (!values.isVirtualAlias) return;
+    if (!values.propertyId || !values.alias?.trim()) {
+      throw new BadRequestException(
+        'Virtual bank accounts require propertyId and alias',
+      );
+    }
   }
 
   async remove(

--- a/backend/src/bank-accounts/dto/create-bank-account.dto.ts
+++ b/backend/src/bank-accounts/dto/create-bank-account.dto.ts
@@ -25,6 +25,26 @@ export class CreateBankAccountDto {
   cbu?: string;
 
   @IsString()
+  @MaxLength(22)
+  @IsOptional()
+  cbuCvu?: string;
+
+  @IsString()
+  @MaxLength(50)
+  @IsOptional()
+  alias?: string;
+
+  @IsString()
+  @MaxLength(200)
+  @IsOptional()
+  holderName?: string;
+
+  @IsString()
+  @MaxLength(20)
+  @IsOptional()
+  holderCuit?: string;
+
+  @IsString()
   @MaxLength(10)
   @IsOptional()
   currency?: string;
@@ -42,5 +62,18 @@ export class CreateBankAccountDto {
   ownerId?: string;
 
   @IsUUID()
-  userId: string;
+  @IsOptional()
+  userId?: string;
+
+  @IsUUID()
+  @IsOptional()
+  propertyId?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  isVirtualAlias?: boolean;
+
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
 }

--- a/backend/src/bank-accounts/entities/bank-account.entity.ts
+++ b/backend/src/bank-accounts/entities/bank-account.entity.ts
@@ -11,18 +11,19 @@ import {
 import { Owner } from '../../owners/entities/owner.entity';
 import { User } from '../../users/entities/user.entity';
 import { Company } from '../../companies/entities/company.entity';
+import { Property } from '../../properties/entities/property.entity';
 
 @Entity('bank_accounts')
 export class BankAccount {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column({ name: 'user_id' })
-  userId: string;
+  @Column({ name: 'user_id', nullable: true, type: 'uuid' })
+  userId: string | null;
 
-  @ManyToOne(() => User)
+  @ManyToOne(() => User, { nullable: true })
   @JoinColumn({ name: 'user_id' })
-  user: User;
+  user: User | null;
 
   @Column({ name: 'company_id' })
   companyId: string;
@@ -38,6 +39,13 @@ export class BankAccount {
   @JoinColumn({ name: 'owner_id' })
   owner: Owner | null;
 
+  @Column({ name: 'property_id', nullable: true, type: 'uuid' })
+  propertyId: string | null;
+
+  @ManyToOne(() => Property, { nullable: true })
+  @JoinColumn({ name: 'property_id' })
+  property: Property | null;
+
   @Column({ name: 'bank_name' })
   bankName: string;
 
@@ -50,11 +58,29 @@ export class BankAccount {
   @Column({ type: 'varchar', nullable: true })
   cbu: string | null;
 
+  @Column({ name: 'cbu_cvu', type: 'varchar', nullable: true })
+  cbuCvu: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  alias: string | null;
+
+  @Column({ name: 'holder_name', type: 'varchar', nullable: true })
+  holderName: string | null;
+
+  @Column({ name: 'holder_cuit', type: 'varchar', nullable: true })
+  holderCuit: string | null;
+
   @Column({ default: 'ARS' })
   currency: string;
 
   @Column({ name: 'is_default', default: false })
   isDefault: boolean;
+
+  @Column({ name: 'is_virtual_alias', default: false })
+  isVirtualAlias: boolean;
+
+  @Column({ name: 'is_active', default: true })
+  isActive: boolean;
 
   @Column({ type: 'text', nullable: true })
   notes: string | null;

--- a/docs/plan-de-trabajo.md
+++ b/docs/plan-de-trabajo.md
@@ -721,10 +721,10 @@ Implementar sistema de cobranza multicanal y liquidación a propietarios.
   - Integración con proveedor (Bind/Pomelo)
   - Webhooks de movimientos
 
-- **T832**: Cuentas virtuales por propiedad
-  - Crear alias virtual
-  - Asociar a propiedad
-  - Identificación automática
+- 🔄 **T832**: Cuentas virtuales por propiedad (EN PROGRESO)
+  - 🔄 Crear alias virtual (persistencia y validación listas; proveedor pendiente)
+  - ✅ Asociar a propiedad con aislamiento por compañía/propietario
+  - ⏳ Identificación automática
 
 ### 8.4 Integración Crypto
 

--- a/docs/technical/payments.md
+++ b/docs/technical/payments.md
@@ -7,6 +7,13 @@ liquidaciones. MercadoPago Checkout Pro está implementado en
 `backend/src/payment-gateway`; las transferencias y cripto permanecen como
 pendientes del plan de trabajo.
 
+La base neutral para cuentas virtuales permite persistir CBU/CVU, alias y la
+propiedad asociada sin acoplarse todavía a Bind o Pomelo. Los alias activos son
+únicos sin perder el historial de cuentas desactivadas o eliminadas, y el API
+valida que usuario, propietario y propiedad pertenezcan a la misma compañía.
+La creación del alias en un proveedor y la conciliación automática continúan
+pendientes.
+
 ## Flujo MercadoPago
 
 1. Un administrador o inquilino autenticado crea una preferencia con
@@ -49,6 +56,9 @@ La tabla de transacciones de la pasarela se crea en
 `migrations/079_add_payment_gateway_transactions.sql`. Toda modificación futura
 del contrato persistido debe agregarse como una migración numerada nueva; las
 migraciones existentes no se editan después de haber sido desplegadas.
+
+La unicidad de alias bancarios activos se incorpora en
+`migrations/092_enforce_active_bank_alias_uniqueness.sql`.
 
 Validación local de la cadena completa:
 

--- a/migrations/092_enforce_active_bank_alias_uniqueness.sql
+++ b/migrations/092_enforce_active_bank_alias_uniqueness.sql
@@ -1,0 +1,23 @@
+-- Ensure a virtual bank alias can identify exactly one active account.
+-- The partial index preserves historical/soft-deleted accounts.
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM bank_accounts
+        WHERE deleted_at IS NULL
+          AND is_active = TRUE
+          AND alias IS NOT NULL
+        GROUP BY LOWER(alias)
+        HAVING COUNT(*) > 1
+    ) THEN
+        RAISE EXCEPTION
+            'Cannot enforce active bank alias uniqueness: duplicate active aliases exist';
+    END IF;
+END
+$$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_bank_accounts_active_alias_unique
+    ON bank_accounts(LOWER(alias))
+    WHERE deleted_at IS NULL AND alias IS NOT NULL AND is_active = TRUE;

--- a/scripts/init-db.sql
+++ b/scripts/init-db.sql
@@ -2629,6 +2629,9 @@ CREATE INDEX idx_bank_accounts_company ON bank_accounts(company_id) WHERE delete
 CREATE INDEX idx_bank_accounts_property ON bank_accounts(property_id) WHERE is_virtual_alias = TRUE;
 CREATE INDEX idx_bank_accounts_default
     ON bank_accounts(company_id, owner_id, is_default) WHERE deleted_at IS NULL;
+CREATE UNIQUE INDEX idx_bank_accounts_active_alias_unique
+    ON bank_accounts(LOWER(alias))
+    WHERE deleted_at IS NULL AND alias IS NOT NULL AND is_active = TRUE;
 
 CREATE TRIGGER update_bank_accounts_updated_at
     BEFORE UPDATE ON bank_accounts FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Qué cambia

- alinea la entidad y el DTO de cuentas bancarias con el esquema existente de CBU/CVU, alias, titular, propiedad y estado
- permite asociar cuentas virtuales a propiedades con aislamiento por compañía y propietario
- fuerza el usuario autenticado al crear como propietario y valida referencias enviadas por administradores
- exige propiedad y alias para una cuenta virtual
- agrega migración 092 e índice único case-insensitive para alias activos, preservando históricos inactivos o eliminados
- actualiza T832 y la documentación técnica sin declarar completa la integración con proveedor

## Por qué

La tabla ya contenía los campos de cuentas virtuales, pero el contrato runtime no los exponía. Además, un propietario podía enviar un `userId` arbitrario y no se validaba que usuario, propietario o propiedad pertenecieran a la misma compañía. Sin unicidad de alias tampoco era posible identificar un movimiento bancario de forma determinística.

## Impacto

Habilita la base neutral para T832 y la futura conciliación T851/T852 sin elegir todavía Bind o Pomelo. No realiza llamadas bancarias ni crea alias en un proveedor externo.

## Validación

- servicio BankAccounts: 23/23 tests; 100% statements/lines/functions y 96% branches
- backend completo: 109 suites, 859/859 tests
- backend coverage: 91,27% statements, 75,08% branches, 82,8% functions, 92% lines
- backend E2E: 9 suites, 53/53 tests
- formato, lint, TypeScript y build verdes
- snapshot PostgreSQL + baseline 090 + migraciones 091/092 verdes
- unicidad SQL comprobada: duplicado activo case-insensitive rechazado; alias histórico inactivo permitido
