### PR TITLE
Add idempotent bank reconciliation sandbox

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -27,6 +27,7 @@ import { AiModule } from './ai/ai.module';
 import { MetricsModule } from './metrics/metrics.module';
 import { BuyersModule } from './buyers/buyers.module';
 import { BankAccountsModule } from './bank-accounts/bank-accounts.module';
+import { BankReconciliationModule } from './bank-reconciliation/bank-reconciliation.module';
 import { SettlementsModule } from './settlements/settlements.module';
 import { MaintenanceModule } from './maintenance/maintenance.module';
 import { NotificationsModule } from './notifications/notifications.module';
@@ -81,6 +82,7 @@ import * as path from 'node:path';
     BuyersModule,
     NotificationsModule,
     BankAccountsModule,
+    BankReconciliationModule,
     SettlementsModule,
     MaintenanceModule,
     PaymentGatewayModule,

--- a/backend/src/bank-reconciliation/bank-reconciliation.controller.spec.ts
+++ b/backend/src/bank-reconciliation/bank-reconciliation.controller.spec.ts
@@ -1,0 +1,55 @@
+import { ForbiddenException } from '@nestjs/common';
+import { BankMovementDirection } from './entities/bank-movement.entity';
+import { BankReconciliationController } from './bank-reconciliation.controller';
+
+describe('BankReconciliationController', () => {
+  const service = {
+    ingestSandboxMovement: jest.fn(),
+    reconcile: jest.fn(),
+  };
+  const controller = new BankReconciliationController(service as any);
+  const request = { user: { companyId: 'company-1' } };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    delete process.env.NODE_ENV;
+  });
+
+  it('forwards sandbox ingestion outside production', async () => {
+    const dto = {
+      externalId: 'movement-1',
+      direction: BankMovementDirection.CREDIT,
+      amount: 100,
+      occurredAt: '2026-08-01',
+    };
+    service.ingestSandboxMovement.mockResolvedValue({ id: 'result' });
+    await expect(
+      controller.ingestSandboxMovement(request, dto),
+    ).resolves.toEqual({ id: 'result' });
+    expect(service.ingestSandboxMovement).toHaveBeenCalledWith(
+      'company-1',
+      dto,
+    );
+  });
+
+  it('disables sandbox ingestion in production', () => {
+    process.env.NODE_ENV = 'production';
+    expect(() =>
+      controller.ingestSandboxMovement(request, {
+        externalId: 'movement-1',
+        direction: BankMovementDirection.CREDIT,
+        amount: 100,
+        occurredAt: '2026-08-01',
+      }),
+    ).toThrow(ForbiddenException);
+    expect(service.ingestSandboxMovement).not.toHaveBeenCalled();
+  });
+
+  it('forwards a manual retry within company scope', async () => {
+    service.reconcile.mockResolvedValue({ id: 'result' });
+    await expect(controller.reconcile(request, 'movement-1')).resolves.toEqual({
+      id: 'result',
+    });
+    expect(service.reconcile).toHaveBeenCalledWith('movement-1', 'company-1');
+  });
+});

--- a/backend/src/bank-reconciliation/bank-reconciliation.controller.ts
+++ b/backend/src/bank-reconciliation/bank-reconciliation.controller.ts
@@ -1,0 +1,42 @@
+import {
+  Body,
+  Controller,
+  ForbiddenException,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Request,
+} from '@nestjs/common';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '../users/entities/user.entity';
+import { BankReconciliationService } from './bank-reconciliation.service';
+import { CreateSandboxBankMovementDto } from './dto/create-sandbox-bank-movement.dto';
+
+interface AuthenticatedRequest {
+  user: { companyId: string };
+}
+
+@Controller('bank-reconciliation')
+@Roles(UserRole.ADMIN, UserRole.STAFF)
+export class BankReconciliationController {
+  constructor(private readonly service: BankReconciliationService) {}
+
+  @Post('sandbox/movements')
+  ingestSandboxMovement(
+    @Request() request: AuthenticatedRequest,
+    @Body() dto: CreateSandboxBankMovementDto,
+  ) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new ForbiddenException('Sandbox bank ingestion is disabled');
+    }
+    return this.service.ingestSandboxMovement(request.user.companyId, dto);
+  }
+
+  @Post('movements/:id/reconcile')
+  reconcile(
+    @Request() request: AuthenticatedRequest,
+    @Param('id', ParseUUIDPipe) id: string,
+  ) {
+    return this.service.reconcile(id, request.user.companyId);
+  }
+}

--- a/backend/src/bank-reconciliation/bank-reconciliation.module.ts
+++ b/backend/src/bank-reconciliation/bank-reconciliation.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BankAccount } from '../bank-accounts/entities/bank-account.entity';
+import { Invoice } from '../payments/entities/invoice.entity';
+import { PaymentsModule } from '../payments/payments.module';
+import { BankReconciliationController } from './bank-reconciliation.controller';
+import { BankReconciliationService } from './bank-reconciliation.service';
+import { BankReconciliation } from './entities/bank-reconciliation.entity';
+import { BankMovement } from './entities/bank-movement.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      BankMovement,
+      BankReconciliation,
+      BankAccount,
+      Invoice,
+    ]),
+    PaymentsModule,
+  ],
+  controllers: [BankReconciliationController],
+  providers: [BankReconciliationService],
+  exports: [BankReconciliationService],
+})
+export class BankReconciliationModule {}

--- a/backend/src/bank-reconciliation/bank-reconciliation.service.spec.ts
+++ b/backend/src/bank-reconciliation/bank-reconciliation.service.spec.ts
@@ -1,0 +1,453 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { BankReconciliationService } from './bank-reconciliation.service';
+import {
+  BankMatchStrategy,
+  BankReconciliationStatus,
+} from './entities/bank-reconciliation.entity';
+import {
+  BankMovementDirection,
+  BankMovementStatus,
+} from './entities/bank-movement.entity';
+import { InvoiceStatus } from '../payments/entities/invoice.entity';
+import { PaymentStatus } from '../payments/entities/payment.entity';
+
+const fluentQuery = (result: { one?: unknown; many?: unknown[] }) => {
+  const query: Record<string, jest.Mock> = {};
+  for (const method of [
+    'where',
+    'andWhere',
+    'innerJoin',
+    'orderBy',
+    'addOrderBy',
+    'take',
+  ]) {
+    query[method] = jest.fn().mockReturnValue(query);
+  }
+  query.getOne = jest.fn().mockResolvedValue(result.one ?? null);
+  query.getMany = jest.fn().mockResolvedValue(result.many ?? []);
+  return query;
+};
+
+describe('BankReconciliationService', () => {
+  const companyId = '10000000-0000-0000-0000-000000000001';
+  const movementId = '20000000-0000-0000-0000-000000000001';
+  const invoiceId = '30000000-0000-0000-0000-000000000001';
+  const paymentId = '40000000-0000-0000-0000-000000000001';
+  const reconciliationId = '50000000-0000-0000-0000-000000000001';
+
+  let movements: any;
+  let reconciliations: any;
+  let bankAccounts: any;
+  let invoices: any;
+  let payments: any;
+  let dataSource: any;
+  let service: BankReconciliationService;
+
+  const movement = (overrides: Record<string, unknown> = {}) => ({
+    id: movementId,
+    companyId,
+    provider: 'sandbox',
+    externalId: 'external-1',
+    direction: BankMovementDirection.CREDIT,
+    amount: 1000,
+    currency: 'ARS',
+    occurredAt: new Date('2026-08-10T12:00:00.000Z'),
+    status: BankMovementStatus.PENDING,
+    bankAccount: { propertyId: '60000000-0000-0000-0000-000000000001' },
+    ...overrides,
+  });
+
+  const invoice = (overrides: Record<string, unknown> = {}) => ({
+    id: invoiceId,
+    companyId,
+    tenantAccountId: '70000000-0000-0000-0000-000000000001',
+    status: InvoiceStatus.PENDING,
+    ...overrides,
+  });
+
+  const reconciliation = (overrides: Record<string, unknown> = {}) => ({
+    id: reconciliationId,
+    companyId,
+    movementId,
+    invoiceId: null,
+    paymentId: null,
+    matchStrategy: null,
+    status: BankReconciliationStatus.PROCESSING,
+    reason: null,
+    matchedAt: null,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    movements = {
+      findOne: jest.fn(),
+      create: jest.fn((value) => value),
+      save: jest.fn(async (value) => value),
+    };
+    reconciliations = {
+      findOne: jest.fn(),
+      create: jest.fn((value) => value),
+      save: jest.fn(async (value) => value),
+    };
+    bankAccounts = {
+      findOne: jest.fn(),
+      createQueryBuilder: jest.fn(),
+    };
+    invoices = { findOne: jest.fn(), createQueryBuilder: jest.fn() };
+    payments = {
+      create: jest.fn(),
+      findOne: jest.fn(),
+      confirm: jest.fn(),
+    };
+    const queryRunner = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      startTransaction: jest.fn().mockResolvedValue(undefined),
+      query: jest.fn().mockResolvedValue(undefined),
+      commitTransaction: jest.fn().mockResolvedValue(undefined),
+      rollbackTransaction: jest.fn().mockResolvedValue(undefined),
+      release: jest.fn().mockResolvedValue(undefined),
+    };
+    dataSource = { createQueryRunner: jest.fn(() => queryRunner) };
+    service = new BankReconciliationService(
+      movements,
+      reconciliations,
+      bankAccounts,
+      invoices,
+      payments,
+      dataSource,
+    );
+  });
+
+  it('ingests, matches by virtual account, confirms and returns a receipt-bearing reconciliation', async () => {
+    const storedMovement = movement({ bankAccountId: 'bank-1' });
+    const storedReconciliation = reconciliation();
+    const result = reconciliation({
+      invoiceId,
+      paymentId,
+      matchStrategy: BankMatchStrategy.VIRTUAL_ALIAS,
+      status: BankReconciliationStatus.MATCHED,
+      movement: storedMovement,
+      payment: { id: paymentId, status: PaymentStatus.COMPLETED },
+    });
+    movements.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(storedMovement);
+    bankAccounts.findOne.mockResolvedValue({ id: 'bank-1' });
+    movements.create.mockReturnValue(storedMovement);
+    reconciliations.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(result);
+    reconciliations.create.mockReturnValue(storedReconciliation);
+    invoices.createQueryBuilder.mockReturnValue(
+      fluentQuery({ one: invoice() }),
+    );
+    payments.create.mockResolvedValue({ id: paymentId });
+    payments.findOne.mockResolvedValue({
+      id: paymentId,
+      status: PaymentStatus.PENDING,
+    });
+    payments.confirm.mockResolvedValue({
+      id: paymentId,
+      status: PaymentStatus.COMPLETED,
+    });
+
+    await expect(
+      service.ingestSandboxMovement(companyId, {
+        externalId: 'external-1',
+        direction: BankMovementDirection.CREDIT,
+        amount: 1000,
+        occurredAt: '2026-08-10T12:00:00.000Z',
+        bankAccountId: 'bank-1',
+      }),
+    ).resolves.toBe(result);
+    expect(payments.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 1000,
+        paymentDate: '2026-08-10',
+        reference: 'sandbox:external-1',
+      }),
+    );
+    expect(payments.confirm).toHaveBeenCalledWith(paymentId);
+    expect(storedMovement.status).toBe(BankMovementStatus.RECONCILED);
+  });
+
+  it('returns an already matched reconciliation for a duplicate external id', async () => {
+    const storedMovement = movement();
+    const matched = reconciliation({
+      status: BankReconciliationStatus.MATCHED,
+    });
+    const expanded = { ...matched, movement: storedMovement };
+    movements.findOne
+      .mockResolvedValueOnce(storedMovement)
+      .mockResolvedValueOnce(storedMovement);
+    reconciliations.findOne
+      .mockResolvedValueOnce(matched)
+      .mockResolvedValueOnce(expanded);
+
+    await expect(
+      service.ingestSandboxMovement(companyId, {
+        externalId: 'external-1',
+        direction: BankMovementDirection.CREDIT,
+        amount: 1000,
+        occurredAt: '2026-08-10',
+      }),
+    ).resolves.toEqual(expanded);
+    expect(movements.create).not.toHaveBeenCalled();
+    expect(payments.create).not.toHaveBeenCalled();
+  });
+
+  it('recovers from concurrent movement ingestion through the unique key', async () => {
+    const concurrentMovement = movement({ bankAccount: null });
+    const matched = reconciliation({
+      status: BankReconciliationStatus.MATCHED,
+    });
+    movements.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(concurrentMovement)
+      .mockResolvedValueOnce(concurrentMovement);
+    movements.create.mockReturnValue(concurrentMovement);
+    movements.save.mockRejectedValueOnce({ code: '23505' });
+    reconciliations.findOne
+      .mockResolvedValueOnce(matched)
+      .mockResolvedValueOnce(matched);
+
+    await expect(
+      service.ingestSandboxMovement(companyId, {
+        externalId: 'external-1',
+        direction: BankMovementDirection.CREDIT,
+        amount: 1000,
+        occurredAt: '2026-08-10',
+      }),
+    ).resolves.toBe(matched);
+  });
+
+  it('recovers from concurrent reconciliation creation through the unique key', async () => {
+    const storedMovement = movement();
+    const concurrent = reconciliation({
+      status: BankReconciliationStatus.MATCHED,
+    });
+    movements.findOne.mockResolvedValue(storedMovement);
+    reconciliations.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(concurrent)
+      .mockResolvedValueOnce(concurrent);
+    reconciliations.save.mockRejectedValueOnce({ code: '23505' });
+
+    await expect(service.reconcile(movementId, companyId)).resolves.toBe(
+      concurrent,
+    );
+  });
+
+  it('ignores debit movements and records why they are unmatched', async () => {
+    const debit = movement({ direction: BankMovementDirection.DEBIT });
+    const storedReconciliation = reconciliation();
+    movements.findOne.mockResolvedValue(debit);
+    reconciliations.findOne.mockResolvedValue(null);
+    reconciliations.create.mockReturnValue(storedReconciliation);
+
+    const result = await service.reconcile(movementId, companyId);
+
+    expect(result.status).toBe(BankReconciliationStatus.UNMATCHED);
+    expect(result.reason).toContain('incoming credit');
+    expect(debit.status).toBe(BankMovementStatus.IGNORED);
+  });
+
+  it('marks a credit unmatched when amount/date matching is ambiguous', async () => {
+    const storedMovement = movement({ bankAccount: null });
+    const storedReconciliation = reconciliation();
+    movements.findOne.mockResolvedValue(storedMovement);
+    reconciliations.findOne.mockResolvedValue(null);
+    reconciliations.create.mockReturnValue(storedReconciliation);
+    invoices.createQueryBuilder.mockReturnValue(
+      fluentQuery({ many: [invoice(), invoice({ id: 'other' })] }),
+    );
+
+    const result = await service.reconcile(movementId, companyId);
+
+    expect(result.status).toBe(BankReconciliationStatus.UNMATCHED);
+    expect(storedMovement.status).toBe(BankMovementStatus.UNMATCHED);
+  });
+
+  it('matches a unique invoice by exact amount and date', async () => {
+    const storedMovement = movement({ bankAccount: null });
+    const storedReconciliation = reconciliation();
+    const final = reconciliation({
+      invoiceId,
+      paymentId,
+      matchStrategy: BankMatchStrategy.EXACT_AMOUNT_DATE,
+      status: BankReconciliationStatus.MATCHED,
+    });
+    movements.findOne.mockResolvedValue(storedMovement);
+    reconciliations.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(final);
+    reconciliations.create.mockReturnValue(storedReconciliation);
+    invoices.createQueryBuilder.mockReturnValue(
+      fluentQuery({ many: [invoice()] }),
+    );
+    payments.create.mockResolvedValue({ id: paymentId });
+    payments.findOne.mockResolvedValue({
+      id: paymentId,
+      status: PaymentStatus.COMPLETED,
+    });
+
+    await expect(service.reconcile(movementId, companyId)).resolves.toBe(final);
+    expect(payments.confirm).not.toHaveBeenCalled();
+    expect(storedReconciliation.matchStrategy).toBe(
+      BankMatchStrategy.EXACT_AMOUNT_DATE,
+    );
+  });
+
+  it('resumes a saved invoice and payment after an interrupted attempt', async () => {
+    const storedMovement = movement();
+    const storedReconciliation = reconciliation({
+      invoiceId,
+      paymentId,
+      matchStrategy: BankMatchStrategy.VIRTUAL_ALIAS,
+      status: BankReconciliationStatus.FAILED,
+    });
+    const final = {
+      ...storedReconciliation,
+      status: BankReconciliationStatus.MATCHED,
+    };
+    movements.findOne.mockResolvedValue(storedMovement);
+    reconciliations.findOne
+      .mockResolvedValueOnce(storedReconciliation)
+      .mockResolvedValueOnce(final);
+    invoices.findOne.mockResolvedValue(invoice());
+    payments.findOne.mockResolvedValue({
+      id: paymentId,
+      status: PaymentStatus.PENDING,
+    });
+    payments.confirm.mockResolvedValue({ status: PaymentStatus.COMPLETED });
+
+    await expect(service.reconcile(movementId, companyId)).resolves.toBe(final);
+    expect(payments.create).not.toHaveBeenCalled();
+    expect(payments.confirm).toHaveBeenCalledWith(paymentId);
+  });
+
+  it('persists a failed status for a non-confirmable payment', async () => {
+    const storedMovement = movement();
+    const storedReconciliation = reconciliation({
+      invoiceId,
+      paymentId,
+      matchStrategy: BankMatchStrategy.VIRTUAL_ALIAS,
+    });
+    movements.findOne.mockResolvedValue(storedMovement);
+    reconciliations.findOne.mockResolvedValue(storedReconciliation);
+    invoices.findOne.mockResolvedValue(invoice());
+    payments.findOne.mockResolvedValue({
+      id: paymentId,
+      status: PaymentStatus.FAILED,
+    });
+
+    await expect(service.reconcile(movementId, companyId)).rejects.toThrow(
+      BadRequestException,
+    );
+    expect(storedReconciliation.status).toBe(BankReconciliationStatus.FAILED);
+    expect(storedReconciliation.reason).toContain('non-confirmable');
+  });
+
+  it('rejects a missing explicit bank account', async () => {
+    movements.findOne
+      .mockResolvedValueOnce(null)
+      .mockImplementation(async () => movement({ bankAccount: null }));
+    bankAccounts.findOne.mockResolvedValue(null);
+    await expect(
+      service.ingestSandboxMovement(companyId, {
+        externalId: 'external-2',
+        direction: BankMovementDirection.CREDIT,
+        amount: 10,
+        occurredAt: '2026-08-10',
+        bankAccountId: 'missing',
+      }),
+    ).rejects.toThrow('Active bank account not found');
+  });
+
+  it('resolves exactly one alias and leaves absent or ambiguous aliases unresolved', async () => {
+    movements.findOne
+      .mockResolvedValueOnce(null)
+      .mockImplementation(async () => movement({ bankAccount: null }));
+    movements.create.mockImplementation((value: any) => ({
+      id: movementId,
+      bankAccount: null,
+      ...value,
+    }));
+    reconciliations.findOne.mockResolvedValue(null);
+    reconciliations.create.mockReturnValue(reconciliation());
+    invoices.createQueryBuilder.mockReturnValue(fluentQuery({ many: [] }));
+
+    bankAccounts.createQueryBuilder.mockReturnValueOnce(
+      fluentQuery({ many: [{ id: 'alias-account' }] }),
+    );
+    await service.ingestSandboxMovement(companyId, {
+      externalId: 'alias-one',
+      direction: BankMovementDirection.CREDIT,
+      amount: 10,
+      occurredAt: '2026-08-10',
+      description: 'alias.one',
+    });
+    expect(movements.create).toHaveBeenLastCalledWith(
+      expect.objectContaining({ bankAccountId: 'alias-account' }),
+    );
+
+    movements.findOne
+      .mockReset()
+      .mockResolvedValueOnce(null)
+      .mockImplementation(async () => movement({ bankAccount: null }));
+    bankAccounts.createQueryBuilder.mockReturnValueOnce(
+      fluentQuery({ many: [{ id: 'one' }, { id: 'two' }] }),
+    );
+    await service.ingestSandboxMovement(companyId, {
+      externalId: 'alias-many',
+      direction: BankMovementDirection.CREDIT,
+      amount: 10,
+      occurredAt: '2026-08-10',
+      description: 'ambiguous aliases',
+    });
+    expect(movements.create).toHaveBeenLastCalledWith(
+      expect.objectContaining({ bankAccountId: null }),
+    );
+  });
+
+  it('ingests a movement without description without attempting alias lookup', async () => {
+    const storedMovement = movement({ bankAccount: null });
+    movements.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(storedMovement);
+    movements.create.mockReturnValue(storedMovement);
+    reconciliations.findOne.mockResolvedValue(null);
+    reconciliations.create.mockReturnValue(reconciliation());
+    invoices.createQueryBuilder.mockReturnValue(fluentQuery({ many: [] }));
+
+    await service.ingestSandboxMovement(companyId, {
+      externalId: 'without-description',
+      direction: BankMovementDirection.CREDIT,
+      amount: 10,
+      occurredAt: '2026-08-10',
+    });
+
+    expect(bankAccounts.createQueryBuilder).not.toHaveBeenCalled();
+    expect(movements.create).toHaveBeenCalledWith(
+      expect.objectContaining({ bankAccountId: null, currency: 'ARS' }),
+    );
+  });
+
+  it('throws when movement or expanded reconciliation is not found', async () => {
+    movements.findOne.mockResolvedValue(null);
+    await expect(service.reconcile(movementId, companyId)).rejects.toThrow(
+      NotFoundException,
+    );
+
+    const storedMovement = movement();
+    movements.findOne.mockResolvedValue(storedMovement);
+    reconciliations.findOne
+      .mockResolvedValueOnce(
+        reconciliation({ status: BankReconciliationStatus.MATCHED }),
+      )
+      .mockResolvedValueOnce(null);
+    await expect(service.reconcile(movementId, companyId)).rejects.toThrow(
+      'Bank reconciliation not found',
+    );
+  });
+});

--- a/backend/src/bank-reconciliation/bank-reconciliation.service.ts
+++ b/backend/src/bank-reconciliation/bank-reconciliation.service.ts
@@ -1,0 +1,373 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { BankAccount } from '../bank-accounts/entities/bank-account.entity';
+import { Invoice, InvoiceStatus } from '../payments/entities/invoice.entity';
+import {
+  PaymentMethod,
+  PaymentStatus,
+} from '../payments/entities/payment.entity';
+import { PaymentsService } from '../payments/payments.service';
+import { CreateSandboxBankMovementDto } from './dto/create-sandbox-bank-movement.dto';
+import {
+  BankMatchStrategy,
+  BankReconciliation,
+  BankReconciliationStatus,
+} from './entities/bank-reconciliation.entity';
+import {
+  BankMovement,
+  BankMovementDirection,
+  BankMovementStatus,
+} from './entities/bank-movement.entity';
+
+type MatchResult = {
+  invoice: Invoice;
+  strategy: BankMatchStrategy;
+};
+
+@Injectable()
+export class BankReconciliationService {
+  private static readonly SANDBOX_PROVIDER = 'sandbox';
+  private static readonly DATE_MATCH_WINDOW_DAYS = 5;
+
+  constructor(
+    @InjectRepository(BankMovement)
+    private readonly movementsRepository: Repository<BankMovement>,
+    @InjectRepository(BankReconciliation)
+    private readonly reconciliationsRepository: Repository<BankReconciliation>,
+    @InjectRepository(BankAccount)
+    private readonly bankAccountsRepository: Repository<BankAccount>,
+    @InjectRepository(Invoice)
+    private readonly invoicesRepository: Repository<Invoice>,
+    private readonly paymentsService: PaymentsService,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  async ingestSandboxMovement(
+    companyId: string,
+    dto: CreateSandboxBankMovementDto,
+  ): Promise<BankReconciliation> {
+    const existingMovement = await this.movementsRepository.findOne({
+      where: {
+        companyId,
+        provider: BankReconciliationService.SANDBOX_PROVIDER,
+        externalId: dto.externalId,
+      },
+    });
+    if (existingMovement) {
+      return this.reconcile(existingMovement.id, companyId);
+    }
+
+    const bankAccountId = await this.resolveBankAccountId(companyId, dto);
+    let movement = this.movementsRepository.create({
+      companyId,
+      bankAccountId,
+      provider: BankReconciliationService.SANDBOX_PROVIDER,
+      externalId: dto.externalId,
+      direction: dto.direction,
+      amount: dto.amount,
+      currency: dto.currency ?? 'ARS',
+      occurredAt: new Date(dto.occurredAt),
+      description: dto.description ?? null,
+      counterparty: dto.counterparty ?? null,
+      rawPayload: dto.rawPayload ?? {},
+      status: BankMovementStatus.PENDING,
+    });
+
+    try {
+      movement = await this.movementsRepository.save(movement);
+    } catch (error) {
+      if (!this.isUniqueViolation(error)) throw error;
+      const concurrent = await this.movementsRepository.findOne({
+        where: {
+          companyId,
+          provider: BankReconciliationService.SANDBOX_PROVIDER,
+          externalId: dto.externalId,
+        },
+      });
+      if (!concurrent) throw error;
+      movement = concurrent;
+    }
+
+    return this.reconcile(movement.id, companyId);
+  }
+
+  async reconcile(
+    movementId: string,
+    companyId: string,
+  ): Promise<BankReconciliation> {
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+    try {
+      await queryRunner.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+        movementId,
+      ]);
+      const result = await this.reconcileLocked(movementId, companyId);
+      await queryRunner.commitTransaction();
+      return result;
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      throw error;
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  private async reconcileLocked(
+    movementId: string,
+    companyId: string,
+  ): Promise<BankReconciliation> {
+    const movement = await this.movementsRepository.findOne({
+      where: { id: movementId, companyId },
+      relations: ['bankAccount'],
+    });
+    if (!movement) {
+      throw new NotFoundException('Bank movement not found');
+    }
+
+    const reconciliation = await this.getOrCreateReconciliation(movement);
+    if (reconciliation.status === BankReconciliationStatus.MATCHED) {
+      return this.findReconciliation(reconciliation.id, companyId);
+    }
+
+    if (movement.direction !== BankMovementDirection.CREDIT) {
+      movement.status = BankMovementStatus.IGNORED;
+      await this.movementsRepository.save(movement);
+      return this.markUnmatched(
+        reconciliation,
+        'Only incoming credit movements can be reconciled',
+      );
+    }
+
+    try {
+      let match: MatchResult | null = null;
+      if (reconciliation.invoiceId && reconciliation.matchStrategy) {
+        const invoice = await this.invoicesRepository.findOne({
+          where: { id: reconciliation.invoiceId, companyId },
+        });
+        if (invoice) {
+          match = { invoice, strategy: reconciliation.matchStrategy };
+        }
+      }
+      match ??= await this.findInvoiceMatch(movement);
+
+      if (!match) {
+        movement.status = BankMovementStatus.UNMATCHED;
+        await this.movementsRepository.save(movement);
+        return this.markUnmatched(
+          reconciliation,
+          'No unique pending invoice matched the movement',
+        );
+      }
+
+      reconciliation.invoiceId = match.invoice.id;
+      reconciliation.matchStrategy = match.strategy;
+      reconciliation.status = BankReconciliationStatus.PROCESSING;
+      reconciliation.reason = null;
+      await this.reconciliationsRepository.save(reconciliation);
+
+      let paymentId = reconciliation.paymentId;
+      if (!paymentId) {
+        const payment = await this.paymentsService.create({
+          tenantAccountId: match.invoice.tenantAccountId,
+          amount: Number(movement.amount),
+          currencyCode: movement.currency,
+          paymentDate: this.toDateOnly(movement.occurredAt),
+          method: PaymentMethod.BANK_TRANSFER,
+          reference: `${movement.provider}:${movement.externalId}`,
+          notes: `Conciliación bancaria automática (${match.strategy})`,
+        });
+        paymentId = payment.id;
+        reconciliation.paymentId = paymentId;
+        await this.reconciliationsRepository.save(reconciliation);
+      }
+
+      const payment = await this.paymentsService.findOne(paymentId);
+      if (payment.status === PaymentStatus.PENDING) {
+        await this.paymentsService.confirm(paymentId);
+      } else if (payment.status !== PaymentStatus.COMPLETED) {
+        throw new BadRequestException(
+          `Reconciliation payment has non-confirmable status: ${payment.status}`,
+        );
+      }
+
+      movement.status = BankMovementStatus.RECONCILED;
+      await this.movementsRepository.save(movement);
+      reconciliation.status = BankReconciliationStatus.MATCHED;
+      reconciliation.matchedAt = new Date();
+      reconciliation.reason = null;
+      await this.reconciliationsRepository.save(reconciliation);
+      return this.findReconciliation(reconciliation.id, companyId);
+    } catch (error) {
+      reconciliation.status = BankReconciliationStatus.FAILED;
+      reconciliation.reason =
+        error instanceof Error ? error.message : 'Reconciliation failed';
+      await this.reconciliationsRepository.save(reconciliation);
+      throw error;
+    }
+  }
+
+  private async resolveBankAccountId(
+    companyId: string,
+    dto: CreateSandboxBankMovementDto,
+  ): Promise<string | null> {
+    if (dto.bankAccountId) {
+      const account = await this.bankAccountsRepository.findOne({
+        where: { id: dto.bankAccountId, companyId, isActive: true },
+      });
+      if (!account) {
+        throw new BadRequestException('Active bank account not found');
+      }
+      return account.id;
+    }
+
+    if (!dto.description) return null;
+    const accounts = await this.bankAccountsRepository
+      .createQueryBuilder('account')
+      .where('account.company_id = :companyId', { companyId })
+      .andWhere('account.is_active = TRUE')
+      .andWhere('account.is_virtual_alias = TRUE')
+      .andWhere('account.deleted_at IS NULL')
+      .andWhere('account.alias IS NOT NULL')
+      .andWhere(
+        "LOWER(:description) LIKE CONCAT('%', LOWER(account.alias), '%')",
+        {
+          description: dto.description,
+        },
+      )
+      .take(2)
+      .getMany();
+    return accounts.length === 1 ? accounts[0].id : null;
+  }
+
+  private async findInvoiceMatch(
+    movement: BankMovement,
+  ): Promise<MatchResult | null> {
+    if (movement.bankAccount?.propertyId) {
+      const invoice = await this.basePendingInvoiceQuery(movement)
+        .andWhere('lease.property_id = :propertyId', {
+          propertyId: movement.bankAccount.propertyId,
+        })
+        .orderBy('invoice.due_date', 'ASC')
+        .addOrderBy('invoice.created_at', 'ASC')
+        .getOne();
+      if (invoice) {
+        return { invoice, strategy: BankMatchStrategy.VIRTUAL_ALIAS };
+      }
+    }
+
+    const candidates = await this.basePendingInvoiceQuery(movement)
+      .andWhere('(invoice.total_amount - invoice.paid_amount) = :amount', {
+        amount: Number(movement.amount),
+      })
+      .andWhere(
+        'ABS(invoice.due_date - CAST(:occurredAt AS date)) <= :dateWindow',
+        {
+          occurredAt: movement.occurredAt.toISOString(),
+          dateWindow: BankReconciliationService.DATE_MATCH_WINDOW_DAYS,
+        },
+      )
+      .take(2)
+      .getMany();
+    return candidates.length === 1
+      ? {
+          invoice: candidates[0],
+          strategy: BankMatchStrategy.EXACT_AMOUNT_DATE,
+        }
+      : null;
+  }
+
+  private basePendingInvoiceQuery(movement: BankMovement) {
+    return this.invoicesRepository
+      .createQueryBuilder('invoice')
+      .innerJoin('invoice.lease', 'lease')
+      .where('invoice.company_id = :companyId', {
+        companyId: movement.companyId,
+      })
+      .andWhere('invoice.status IN (:...statuses)', {
+        statuses: [
+          InvoiceStatus.PENDING,
+          InvoiceStatus.SENT,
+          InvoiceStatus.PARTIAL,
+          InvoiceStatus.OVERDUE,
+        ],
+      })
+      .andWhere('invoice.tenant_account_id IS NOT NULL')
+      .andWhere('invoice.currency = :currency', {
+        currency: movement.currency,
+      });
+  }
+
+  private async getOrCreateReconciliation(
+    movement: BankMovement,
+  ): Promise<BankReconciliation> {
+    const existing = await this.reconciliationsRepository.findOne({
+      where: { movementId: movement.id },
+    });
+    if (existing) return existing;
+
+    try {
+      return await this.reconciliationsRepository.save(
+        this.reconciliationsRepository.create({
+          companyId: movement.companyId,
+          movementId: movement.id,
+          invoiceId: null,
+          paymentId: null,
+          matchStrategy: null,
+          status: BankReconciliationStatus.PROCESSING,
+          reason: null,
+          matchedAt: null,
+        }),
+      );
+    } catch (error) {
+      if (!this.isUniqueViolation(error)) throw error;
+      const concurrent = await this.reconciliationsRepository.findOne({
+        where: { movementId: movement.id },
+      });
+      if (!concurrent) throw error;
+      return concurrent;
+    }
+  }
+
+  private async markUnmatched(
+    reconciliation: BankReconciliation,
+    reason: string,
+  ): Promise<BankReconciliation> {
+    reconciliation.status = BankReconciliationStatus.UNMATCHED;
+    reconciliation.reason = reason;
+    reconciliation.matchedAt = null;
+    return this.reconciliationsRepository.save(reconciliation);
+  }
+
+  private async findReconciliation(
+    id: string,
+    companyId: string,
+  ): Promise<BankReconciliation> {
+    const reconciliation = await this.reconciliationsRepository.findOne({
+      where: { id, companyId },
+      relations: ['movement', 'invoice', 'payment', 'payment.receipt'],
+    });
+    if (!reconciliation) {
+      throw new NotFoundException('Bank reconciliation not found');
+    }
+    return reconciliation;
+  }
+
+  private toDateOnly(value: Date): string {
+    return value.toISOString().slice(0, 10);
+  }
+
+  private isUniqueViolation(error: unknown): boolean {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      (error as { code?: string }).code === '23505'
+    );
+  }
+}

--- a/backend/src/bank-reconciliation/dto/create-sandbox-bank-movement.dto.ts
+++ b/backend/src/bank-reconciliation/dto/create-sandbox-bank-movement.dto.ts
@@ -1,0 +1,48 @@
+import {
+  IsDateString,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Min,
+} from 'class-validator';
+import { BankMovementDirection } from '../entities/bank-movement.entity';
+
+export class CreateSandboxBankMovementDto {
+  @IsString()
+  @IsNotEmpty()
+  externalId: string;
+
+  @IsEnum(BankMovementDirection)
+  direction: BankMovementDirection;
+
+  @IsNumber()
+  @Min(0.01)
+  amount: number;
+
+  @IsString()
+  @IsOptional()
+  currency?: string = 'ARS';
+
+  @IsDateString()
+  occurredAt: string;
+
+  @IsUUID()
+  @IsOptional()
+  bankAccountId?: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsString()
+  @IsOptional()
+  counterparty?: string;
+
+  @IsObject()
+  @IsOptional()
+  rawPayload?: Record<string, unknown>;
+}

--- a/backend/src/bank-reconciliation/entities/bank-movement.entity.ts
+++ b/backend/src/bank-reconciliation/entities/bank-movement.entity.ts
@@ -1,0 +1,79 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { BankAccount } from '../../bank-accounts/entities/bank-account.entity';
+import { Company } from '../../companies/entities/company.entity';
+
+export enum BankMovementDirection {
+  CREDIT = 'credit',
+  DEBIT = 'debit',
+}
+
+export enum BankMovementStatus {
+  PENDING = 'pending',
+  RECONCILED = 'reconciled',
+  UNMATCHED = 'unmatched',
+  IGNORED = 'ignored',
+}
+
+@Entity('bank_movements')
+export class BankMovement {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'company_id', type: 'uuid' })
+  companyId: string;
+
+  @ManyToOne(() => Company)
+  @JoinColumn({ name: 'company_id' })
+  company: Company;
+
+  @Column({ name: 'bank_account_id', type: 'uuid', nullable: true })
+  bankAccountId: string | null;
+
+  @ManyToOne(() => BankAccount, { nullable: true })
+  @JoinColumn({ name: 'bank_account_id' })
+  bankAccount: BankAccount | null;
+
+  @Column({ type: 'varchar', length: 50 })
+  provider: string;
+
+  @Column({ name: 'external_id', type: 'varchar', length: 150 })
+  externalId: string;
+
+  @Column({ type: 'varchar', length: 10 })
+  direction: BankMovementDirection;
+
+  @Column({ type: 'decimal', precision: 14, scale: 2 })
+  amount: number;
+
+  @Column({ type: 'varchar', length: 10, default: 'ARS' })
+  currency: string;
+
+  @Column({ name: 'occurred_at', type: 'timestamptz' })
+  occurredAt: Date;
+
+  @Column({ type: 'text', nullable: true })
+  description: string | null;
+
+  @Column({ type: 'varchar', length: 200, nullable: true })
+  counterparty: string | null;
+
+  @Column({ name: 'raw_payload', type: 'jsonb', default: {} })
+  rawPayload: Record<string, unknown>;
+
+  @Column({ type: 'varchar', length: 20, default: BankMovementStatus.PENDING })
+  status: BankMovementStatus;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+  updatedAt: Date;
+}

--- a/backend/src/bank-reconciliation/entities/bank-reconciliation.entity.ts
+++ b/backend/src/bank-reconciliation/entities/bank-reconciliation.entity.ts
@@ -1,0 +1,88 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Company } from '../../companies/entities/company.entity';
+import { Invoice } from '../../payments/entities/invoice.entity';
+import { Payment } from '../../payments/entities/payment.entity';
+import { BankMovement } from './bank-movement.entity';
+
+export enum BankMatchStrategy {
+  VIRTUAL_ALIAS = 'virtual_alias',
+  EXACT_AMOUNT_DATE = 'exact_amount_date',
+  MANUAL = 'manual',
+}
+
+export enum BankReconciliationStatus {
+  PROCESSING = 'processing',
+  MATCHED = 'matched',
+  UNMATCHED = 'unmatched',
+  FAILED = 'failed',
+}
+
+@Entity('bank_reconciliations')
+export class BankReconciliation {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'company_id', type: 'uuid' })
+  companyId: string;
+
+  @ManyToOne(() => Company)
+  @JoinColumn({ name: 'company_id' })
+  company: Company;
+
+  @Column({ name: 'movement_id', type: 'uuid' })
+  movementId: string;
+
+  @OneToOne(() => BankMovement)
+  @JoinColumn({ name: 'movement_id' })
+  movement: BankMovement;
+
+  @Column({ name: 'invoice_id', type: 'uuid', nullable: true })
+  invoiceId: string | null;
+
+  @ManyToOne(() => Invoice, { nullable: true })
+  @JoinColumn({ name: 'invoice_id' })
+  invoice: Invoice | null;
+
+  @Column({ name: 'payment_id', type: 'uuid', nullable: true })
+  paymentId: string | null;
+
+  @ManyToOne(() => Payment, { nullable: true })
+  @JoinColumn({ name: 'payment_id' })
+  payment: Payment | null;
+
+  @Column({
+    name: 'match_strategy',
+    type: 'varchar',
+    length: 30,
+    nullable: true,
+  })
+  matchStrategy: BankMatchStrategy | null;
+
+  @Column({
+    type: 'varchar',
+    length: 20,
+    default: BankReconciliationStatus.PROCESSING,
+  })
+  status: BankReconciliationStatus;
+
+  @Column({ type: 'text', nullable: true })
+  reason: string | null;
+
+  @Column({ name: 'matched_at', type: 'timestamptz', nullable: true })
+  matchedAt: Date | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+  updatedAt: Date;
+}

--- a/backend/test/payment-flow.e2e-spec.ts
+++ b/backend/test/payment-flow.e2e-spec.ts
@@ -52,6 +52,8 @@ describe('Payment accounting flow (e2e)', () => {
   let adminToken: string;
   let tenantAccountId: string;
   let invoiceId: string;
+  let ownerId: string;
+  let propertyId: string;
 
   const uniqueId = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 
@@ -120,6 +122,7 @@ describe('Payment accounting flow (e2e)', () => {
     const owner = await ownerRepository.save(
       ownerRepository.create({ userId: ownerUser.id, companyId }),
     );
+    ownerId = owner.id;
 
     const tenantUser = await createActiveTestUser(usersService, {
       email: `tenant-${uniqueId}@payment-flow.test`,
@@ -144,6 +147,7 @@ describe('Payment accounting flow (e2e)', () => {
         addressState: 'Buenos Aires',
       }),
     );
+    propertyId = property.id;
     const lease = await leaseRepository.save(
       leaseRepository.create({
         companyId,
@@ -195,6 +199,14 @@ describe('Payment accounting flow (e2e)', () => {
   afterAll(async () => {
     if (companyId) {
       await dataSource.query(
+        `DELETE FROM bank_reconciliations WHERE company_id = $1::uuid`,
+        [companyId],
+      );
+      await dataSource.query(
+        `DELETE FROM bank_movements WHERE company_id = $1::uuid`,
+        [companyId],
+      );
+      await dataSource.query(
         `DELETE FROM documents WHERE company_id = $1::uuid`,
         [companyId],
       );
@@ -222,6 +234,10 @@ describe('Payment accounting flow (e2e)', () => {
       );
       await dataSource.query(
         `DELETE FROM invoices WHERE company_id = $1::uuid`,
+        [companyId],
+      );
+      await dataSource.query(
+        `DELETE FROM bank_accounts WHERE company_id = $1::uuid`,
         [companyId],
       );
       await dataSource.query(
@@ -343,5 +359,109 @@ describe('Payment accounting flow (e2e)', () => {
       .expect(200);
     expect(Buffer.isBuffer(pdf.body)).toBe(true);
     expect(pdf.body.subarray(0, 4).toString()).toBe('%PDF');
+  });
+
+  it('ingests an idempotent sandbox credit and reconciles it by virtual alias', async () => {
+    expect.hasAssertions();
+
+    const alias = `rent.${uniqueId}`.slice(0, 50);
+    const account = await request(app.getHttpServer())
+      .post('/bank-accounts')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        ownerId,
+        propertyId,
+        bankName: 'Sandbox Bank',
+        accountType: 'virtual',
+        accountNumber: `VIRTUAL-${uniqueId}`,
+        alias,
+        isVirtualAlias: true,
+      })
+      .expect(201);
+
+    const reconciliationInvoice = await invoiceRepository.save(
+      invoiceRepository.create({
+        companyId,
+        leaseId: (
+          await tenantAccountRepository.findOneByOrFail({
+            id: tenantAccountId,
+          })
+        ).leaseId,
+        ownerId,
+        tenantAccountId,
+        invoiceNumber: `INV-RECON-${uniqueId}`,
+        periodStart: new Date('2026-08-01'),
+        periodEnd: new Date('2026-08-31'),
+        issuedAt: new Date('2026-08-01'),
+        dueDate: new Date('2026-08-10'),
+        subtotal: 750,
+        total: 750,
+        balanceDue: 750,
+        currencyCode: 'ARS',
+        amountPaid: 0,
+        status: InvoiceStatus.PENDING,
+      }),
+    );
+    await dataSource.query(
+      `UPDATE tenant_accounts SET current_balance = 750 WHERE id = $1::uuid`,
+      [tenantAccountId],
+    );
+
+    const payload = {
+      externalId: `sandbox-credit-${uniqueId}`,
+      direction: 'credit',
+      amount: 750,
+      currency: 'ARS',
+      occurredAt: '2026-08-10T14:00:00.000Z',
+      description: `Transferencia recibida a ${alias}`,
+      counterparty: 'Tenant Sandbox',
+      rawPayload: { fixture: true },
+    };
+    const first = await request(app.getHttpServer())
+      .post('/bank-reconciliation/sandbox/movements')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send(payload)
+      .expect(201);
+
+    expect(first.body).toMatchObject({
+      invoiceId: reconciliationInvoice.id,
+      matchStrategy: 'virtual_alias',
+      status: 'matched',
+      movement: {
+        bankAccountId: account.body.id,
+        externalId: payload.externalId,
+        status: 'reconciled',
+      },
+      payment: {
+        status: 'completed',
+        method: PaymentMethod.BANK_TRANSFER,
+      },
+    });
+    expect(first.body.payment.receipt.pdfUrl).toMatch(/^db:\/\/document\//);
+
+    const retried = await request(app.getHttpServer())
+      .post('/bank-reconciliation/sandbox/movements')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send(payload)
+      .expect(201);
+    expect(retried.body.id).toBe(first.body.id);
+    expect(retried.body.paymentId).toBe(first.body.paymentId);
+
+    const [counts] = await dataSource.query(
+      `SELECT
+         (SELECT COUNT(*) FROM bank_movements
+          WHERE company_id = $1::uuid AND external_id = $2) AS movements,
+         (SELECT COUNT(*) FROM payments
+          WHERE company_id = $1::uuid AND reference_number = $3) AS payments`,
+      [companyId, payload.externalId, `sandbox:${payload.externalId}`],
+    );
+    expect(Number(counts.movements)).toBe(1);
+    expect(Number(counts.payments)).toBe(1);
+
+    const refreshedInvoice = await invoiceRepository.findOneByOrFail({
+      id: reconciliationInvoice.id,
+    });
+    expect(refreshedInvoice.status).toBe(InvoiceStatus.PAID);
+    expect(Number(refreshedInvoice.amountPaid)).toBe(750);
   });
 });

--- a/docs/plan-de-trabajo.md
+++ b/docs/plan-de-trabajo.md
@@ -716,15 +716,15 @@ Implementar sistema de cobranza multicanal y liquidación a propietarios.
 
 ### 8.3 Integración Bancaria
 
-- **T831**: Servicio de transferencias
-  - BankTransferService
-  - Integración con proveedor (Bind/Pomelo)
-  - Webhooks de movimientos
+- 🔄 **T831**: Servicio de transferencias (EN PROGRESO)
+  - ✅ Persistencia neutral e idempotente de movimientos bancarios
+  - ⏳ Integración con proveedor (Bind/Pomelo)
+  - ⏳ Webhooks de movimientos
 
 - 🔄 **T832**: Cuentas virtuales por propiedad (EN PROGRESO)
   - 🔄 Crear alias virtual (persistencia y validación listas; proveedor pendiente)
   - ✅ Asociar a propiedad con aislamiento por compañía/propietario
-  - ⏳ Identificación automática
+  - ✅ Identificación automática por alias en movimientos normalizados
 
 ### 8.4 Integración Crypto
 
@@ -745,11 +745,11 @@ Implementar sistema de cobranza multicanal y liquidación a propietarios.
 
 ### 8.5 Conciliación
 
-- **T851**: Servicio de conciliación
-  - ReconciliationService
-  - Matching por alias
-  - Matching por monto/fecha
-  - Alertas de no conciliados
+- 🔄 **T851**: Servicio de conciliación (EN PROGRESO)
+  - ✅ BankReconciliationService idempotente y aislado por compañía
+  - ✅ Matching por alias/propiedad
+  - ✅ Matching único por monto/fecha
+  - ⏳ Alertas de no conciliados
 
 - **T852**: Comando `reconcile-bank`
   - Procesar movimientos bancarios
@@ -803,10 +803,11 @@ Implementar sistema de cobranza multicanal y liquidación a propietarios.
   - ✅ Mocks de MercadoPago
   - ⏳ Mocks de bancos
 
-- 🔄 **T892**: Tests de integración (EN PROGRESO)
+- ✅ **T892**: Tests de integración
   - ✅ Flujo completo de pago: confirmación, cuenta corriente, factura, recibo y PDF
     (`backend/test/payment-flow.e2e-spec.ts`)
-  - ⏳ Conciliación
+  - ✅ Conciliación bancaria sandbox: alias, pago contable, factura, recibo e idempotencia
+    (`backend/test/payment-flow.e2e-spec.ts`)
   - ✅ Liquidación: cálculo, comisión, persistencia, transferencia simulada y estado final
     (`Batch E2E` en `.github/workflows/ci.yml`)
 

--- a/docs/technical/payments.md
+++ b/docs/technical/payments.md
@@ -4,15 +4,35 @@
 
 El dominio de pagos conecta facturas, cuentas corrientes, pagos, recibos y
 liquidaciones. MercadoPago Checkout Pro está implementado en
-`backend/src/payment-gateway`; las transferencias y cripto permanecen como
-pendientes del plan de trabajo.
+`backend/src/payment-gateway`. La base neutral de transferencias y la
+conciliación sandbox están implementadas; la conexión con un proveedor bancario
+real y cripto permanecen pendientes del plan de trabajo.
 
 La base neutral para cuentas virtuales permite persistir CBU/CVU, alias y la
 propiedad asociada sin acoplarse todavía a Bind o Pomelo. Los alias activos son
 únicos sin perder el historial de cuentas desactivadas o eliminadas, y el API
 valida que usuario, propietario y propiedad pertenezcan a la misma compañía.
-La creación del alias en un proveedor y la conciliación automática continúan
-pendientes.
+La creación del alias en un proveedor continúa pendiente. Los movimientos ya
+pueden identificarse automáticamente por alias y conciliarse contra facturas.
+
+## Conciliación bancaria neutral
+
+`backend/src/bank-reconciliation` persiste movimientos normalizados con una
+clave idempotente por compañía, proveedor e identificador externo. Los créditos
+entrantes se asocian primero por cuenta virtual/propiedad y, si no hay cuenta,
+por coincidencia única de monto y fecha dentro de una ventana de cinco días.
+
+Una coincidencia crea y confirma un pago mediante `PaymentsService`, por lo que
+aplica el mismo flujo contable FIFO y genera el mismo recibo PDF que un pago
+registrado desde el API. El movimiento y su conciliación quedan vinculados a la
+factura y al pago. Un bloqueo transaccional por movimiento serializa reintentos
+concurrentes y evita pagos duplicados.
+
+Para desarrollo y CI existe `POST /bank-reconciliation/sandbox/movements`. El
+endpoint está deshabilitado cuando `NODE_ENV=production`; no representa un
+webhook productivo ni llama a Bind o Pomelo. Los movimientos no conciliados se
+persisten para revisión, pero sus alertas y el comando batch `reconcile-bank`
+siguen pendientes.
 
 ## Flujo MercadoPago
 
@@ -59,6 +79,8 @@ migraciones existentes no se editan después de haber sido desplegadas.
 
 La unicidad de alias bancarios activos se incorpora en
 `migrations/092_enforce_active_bank_alias_uniqueness.sql`.
+Las tablas `bank_movements` y `bank_reconciliations` se incorporan en
+`migrations/093_add_bank_movement_reconciliation.sql`.
 
 Validación local de la cadena completa:
 
@@ -66,6 +88,7 @@ Validación local de la cadena completa:
 ./migrations/run-migrations.sh
 cd backend
 npm run test:e2e -- --runInBand payment-gateway.e2e-spec.ts
+npm run test:e2e -- --runInBand payment-flow.e2e-spec.ts
 ```
 
 ## Salida a producción

--- a/migrations/093_add_bank_movement_reconciliation.sql
+++ b/migrations/093_add_bank_movement_reconciliation.sql
@@ -1,0 +1,55 @@
+-- Provider-neutral bank movement ingestion and reconciliation.
+
+CREATE TABLE IF NOT EXISTS bank_movements (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+    bank_account_id UUID REFERENCES bank_accounts(id) ON DELETE SET NULL,
+    provider VARCHAR(50) NOT NULL,
+    external_id VARCHAR(150) NOT NULL,
+    direction VARCHAR(10) NOT NULL CHECK (direction IN ('credit', 'debit')),
+    amount DECIMAL(14, 2) NOT NULL CHECK (amount > 0),
+    currency VARCHAR(10) NOT NULL DEFAULT 'ARS',
+    occurred_at TIMESTAMPTZ NOT NULL,
+    description TEXT,
+    counterparty VARCHAR(200),
+    raw_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'reconciled', 'unmatched', 'ignored')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_bank_movements_provider_external
+        UNIQUE (company_id, provider, external_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_bank_movements_pending
+    ON bank_movements(company_id, occurred_at)
+    WHERE status IN ('pending', 'unmatched');
+
+CREATE TABLE IF NOT EXISTS bank_reconciliations (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+    movement_id UUID NOT NULL REFERENCES bank_movements(id) ON DELETE CASCADE,
+    invoice_id UUID REFERENCES invoices(id) ON DELETE SET NULL,
+    payment_id UUID REFERENCES payments(id) ON DELETE SET NULL,
+    match_strategy VARCHAR(30)
+        CHECK (match_strategy IN ('virtual_alias', 'exact_amount_date', 'manual')),
+    status VARCHAR(20) NOT NULL DEFAULT 'processing'
+        CHECK (status IN ('processing', 'matched', 'unmatched', 'failed')),
+    reason TEXT,
+    matched_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_bank_reconciliations_movement UNIQUE (movement_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_bank_reconciliations_company_status
+    ON bank_reconciliations(company_id, status, created_at DESC);
+
+DROP TRIGGER IF EXISTS update_bank_movements_updated_at ON bank_movements;
+CREATE TRIGGER update_bank_movements_updated_at
+    BEFORE UPDATE ON bank_movements FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+DROP TRIGGER IF EXISTS update_bank_reconciliations_updated_at ON bank_reconciliations;
+CREATE TRIGGER update_bank_reconciliations_updated_at
+    BEFORE UPDATE ON bank_reconciliations FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+

--- a/scripts/init-db.sql
+++ b/scripts/init-db.sql
@@ -2638,6 +2638,51 @@ CREATE TRIGGER update_bank_accounts_updated_at
 
 COMMENT ON TABLE bank_accounts IS 'Bank accounts for owners and companies (CBU/CVU/Alias)';
 
+-- Provider-neutral movements and automatic reconciliation (T831/T851)
+CREATE TABLE bank_movements (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+    bank_account_id UUID REFERENCES bank_accounts(id) ON DELETE SET NULL,
+    provider VARCHAR(50) NOT NULL,
+    external_id VARCHAR(150) NOT NULL,
+    direction VARCHAR(10) NOT NULL CHECK (direction IN ('credit', 'debit')),
+    amount DECIMAL(14, 2) NOT NULL CHECK (amount > 0),
+    currency VARCHAR(10) NOT NULL DEFAULT 'ARS',
+    occurred_at TIMESTAMPTZ NOT NULL,
+    description TEXT,
+    counterparty VARCHAR(200),
+    raw_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'reconciled', 'unmatched', 'ignored')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (company_id, provider, external_id)
+);
+CREATE INDEX idx_bank_movements_pending ON bank_movements(company_id, occurred_at)
+    WHERE status IN ('pending', 'unmatched');
+CREATE TRIGGER update_bank_movements_updated_at
+    BEFORE UPDATE ON bank_movements FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TABLE bank_reconciliations (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+    movement_id UUID NOT NULL UNIQUE REFERENCES bank_movements(id) ON DELETE CASCADE,
+    invoice_id UUID REFERENCES invoices(id) ON DELETE SET NULL,
+    payment_id UUID REFERENCES payments(id) ON DELETE SET NULL,
+    match_strategy VARCHAR(30)
+        CHECK (match_strategy IN ('virtual_alias', 'exact_amount_date', 'manual')),
+    status VARCHAR(20) NOT NULL DEFAULT 'processing'
+        CHECK (status IN ('processing', 'matched', 'unmatched', 'failed')),
+    reason TEXT,
+    matched_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_bank_reconciliations_company_status
+    ON bank_reconciliations(company_id, status, created_at DESC);
+CREATE TRIGGER update_bank_reconciliations_updated_at
+    BEFORE UPDATE ON bank_reconciliations FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
 -- -----------------------------------------------------------------------------
 -- Crypto Wallets (T812)
 -- -----------------------------------------------------------------------------


### PR DESCRIPTION
## Qué cambia

- agrega persistencia neutral e idempotente de movimientos bancarios y conciliaciones
- identifica cuentas virtuales por alias/propiedad y usa matching único por monto/fecha como fallback
- crea y confirma pagos mediante el flujo contable real, con serialización de reintentos concurrentes
- incorpora la migración 093 y actualiza el snapshot de inicialización
- extiende el E2E de pagos con conciliación, factura, recibo PDF e idempotencia
- actualiza el plan de trabajo y la documentación técnica

## Impacto

Completa el E2E de conciliación (T892) y deja T831/T851 en progreso sólo por proveedor, webhooks y alertas. El endpoint de ingestión es exclusivamente sandbox y está deshabilitado en producción.

## Validación

- backend unit: 111 suites, 875 tests
- backend coverage: 91.36% statements, 75.30% branches, 82.65% functions, 92.11% lines
- backend E2E: 9 suites, 54 tests
- conciliación focalizada: 100% lines/functions, 96.89% statements, 88.70% branches
- migraciones 091-093 sobre snapshot con baseline 090
- lint, type-check, build y format check