### PR TITLE
Add bank reconciliation batch alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,8 @@ WHATSAPP_VERIFY_TOKEN=your_custom_verify_token_here
 
 # Shared secret for batch -> backend internal WhatsApp endpoint
 BATCH_WHATSAPP_INTERNAL_TOKEN=replace_with_shared_secret
+BATCH_BANK_RECONCILIATION_INTERNAL_TOKEN=replace_with_separate_shared_secret
+BACKEND_INTERNAL_URL=http://localhost:3001
 WHATSAPP_DOCUMENTS_BASE_URL=$FRONTEND_URL
 WHATSAPP_DOCUMENT_LINK_SECRET=replace_with_document_link_secret
 WHATSAPP_DOCUMENT_LINK_TTL_SECONDS=604800

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,12 +437,16 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-npm-batch-${{ hashFiles('batch/package-lock.json') }}
+          key: ${{ runner.os }}-npm-bank-e2e-${{ hashFiles('batch/package-lock.json', 'backend/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-npm-batch-
+            ${{ runner.os }}-npm-bank-e2e-
 
-      - name: Install dependencies
+      - name: Install batch dependencies
         working-directory: batch
+        run: npm ci
+
+      - name: Install backend dependencies
+        working-directory: backend
         run: npm ci
 
       - name: Install PostgreSQL client
@@ -474,9 +478,254 @@ jobs:
           npm run dev -- billing --dry-run
           npm run dev -- overdue --dry-run
           npm run dev -- lease-renewal-alerts --dry-run
+          npm run dev -- reconcile-bank --dry-run --min-age-minutes 0
         env:
           DATABASE_URL: postgresql://test:test@localhost:5432/rent_test
           NODE_ENV: test
+
+      - name: Seed bank reconciliation integration fixture
+        run: |
+          psql -v ON_ERROR_STOP=1 "$DATABASE_URL" <<'SQL'
+          INSERT INTO invoices (
+            id, company_id, lease_id, owner_id, tenant_account_id,
+            invoice_number, status, issue_date, due_date, period_start,
+            period_end, subtotal, total_amount, balance_due, currency
+          ) VALUES (
+            'cccccccc-cccc-cccc-cccc-cccccccccccc',
+            '11111111-1111-1111-1111-111111111111',
+            '88888888-8888-8888-8888-888888888888',
+            '33333333-3333-3333-3333-333333333333',
+            '99999999-9999-9999-9999-999999999999',
+            'INV-BANK-E2E', 'pending', CURRENT_DATE, CURRENT_DATE,
+            DATE_TRUNC('month', CURRENT_DATE)::date,
+            (DATE_TRUNC('month', CURRENT_DATE) + INTERVAL '1 month - 1 day')::date,
+            43210.00, 43210.00, 43210.00, 'ARS'
+          );
+
+          UPDATE tenant_accounts
+             SET current_balance = 43210.00
+           WHERE id = '99999999-9999-9999-9999-999999999999';
+
+          INSERT INTO bank_movements (
+            id, company_id, provider, external_id, direction, amount,
+            currency, occurred_at, description, raw_payload, status
+          ) VALUES (
+            'dddddddd-dddd-dddd-dddd-dddddddddddd',
+            '11111111-1111-1111-1111-111111111111',
+            'ci-bank', 'ci-bank-credit-1', 'credit', 43210.00,
+            'ARS', NOW() - INTERVAL '10 minutes',
+            'Batch reconciliation integration fixture', '{}'::jsonb, 'pending'
+          );
+
+          INSERT INTO bank_movements (
+            id, company_id, provider, external_id, direction, amount,
+            currency, occurred_at, description, raw_payload, status
+          ) VALUES (
+            'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+            '11111111-1111-1111-1111-111111111111',
+            'ci-bank', 'ci-bank-unmatched-1', 'credit', 98765.00,
+            'ARS', NOW() - INTERVAL '10 minutes',
+            'Unmatched reconciliation integration fixture', '{}'::jsonb, 'pending'
+          );
+          SQL
+        env:
+          DATABASE_URL: postgresql://test:test@localhost:5432/rent_test
+
+      - name: Start backend for bank reconciliation
+        working-directory: backend
+        run: |
+          npm run start > "$RUNNER_TEMP/rent-backend.log" 2>&1 &
+          echo "$!" > "$RUNNER_TEMP/rent-backend.pid"
+          for attempt in $(seq 1 45); do
+            if curl --fail --silent http://localhost:3001/health >/dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+          cat "$RUNNER_TEMP/rent-backend.log"
+          exit 1
+        env:
+          DATABASE_URL: postgresql://test:test@localhost:5432/rent_test
+          JWT_SECRET: test-secret
+          JWT_REFRESH_SECRET: test-refresh-secret
+          BATCH_BANK_RECONCILIATION_INTERNAL_TOKEN: ci-bank-token
+          NODE_ENV: test
+
+      - name: Run bank reconciliation integration flow
+        working-directory: batch
+        run: >-
+          npm run dev -- reconcile-bank
+          --company-id 11111111-1111-1111-1111-111111111111
+          --limit 10
+          --min-age-minutes 0
+        env:
+          DATABASE_URL: postgresql://test:test@localhost:5432/rent_test
+          BACKEND_INTERNAL_URL: http://localhost:3001
+          BATCH_BANK_RECONCILIATION_INTERNAL_TOKEN: ci-bank-token
+          NODE_ENV: test
+
+      - name: Verify bank reconciliation integration flow
+        run: |
+          psql -v ON_ERROR_STOP=1 "$DATABASE_URL" <<'SQL'
+          DO $assert$
+          DECLARE
+            movement_status TEXT;
+            reconciliation_status TEXT;
+            invoice_status TEXT;
+            payment_count INTEGER;
+            alert_count INTEGER;
+            job_status TEXT;
+            unmatched_movement_status TEXT;
+            unmatched_reconciliation_status TEXT;
+            unmatched_alert_status TEXT;
+          BEGIN
+            SELECT status INTO movement_status
+              FROM bank_movements
+             WHERE id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+            SELECT status INTO reconciliation_status
+              FROM bank_reconciliations
+             WHERE movement_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+            SELECT status INTO invoice_status
+              FROM invoices
+             WHERE id = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+            SELECT COUNT(*) INTO payment_count
+              FROM payments
+             WHERE reference_number = 'ci-bank:ci-bank-credit-1'
+               AND status = 'completed';
+            SELECT COUNT(*) INTO alert_count
+              FROM bank_reconciliation_alerts
+             WHERE movement_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd'
+               AND status = 'open';
+            SELECT status INTO job_status
+              FROM billing_jobs
+             WHERE job_type = 'reconcile_bank'
+             ORDER BY created_at DESC
+             LIMIT 1;
+            SELECT status INTO unmatched_movement_status
+              FROM bank_movements
+             WHERE id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+            SELECT status INTO unmatched_reconciliation_status
+              FROM bank_reconciliations
+             WHERE movement_id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+            SELECT status INTO unmatched_alert_status
+              FROM bank_reconciliation_alerts
+             WHERE movement_id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+
+            IF movement_status <> 'reconciled'
+              OR reconciliation_status <> 'matched'
+              OR invoice_status <> 'paid'
+              OR payment_count <> 1
+              OR alert_count <> 0
+              OR job_status <> 'completed'
+              OR unmatched_movement_status <> 'unmatched'
+              OR unmatched_reconciliation_status <> 'unmatched'
+              OR unmatched_alert_status <> 'open' THEN
+              RAISE EXCEPTION
+                'Unexpected reconciliation state: movement %, reconciliation %, invoice %, payments %, alerts %, job %, unmatched movement %, unmatched reconciliation %, unmatched alert %',
+                movement_status, reconciliation_status, invoice_status,
+                payment_count, alert_count, job_status,
+                unmatched_movement_status, unmatched_reconciliation_status,
+                unmatched_alert_status;
+            END IF;
+          END $assert$;
+          SQL
+        env:
+          DATABASE_URL: postgresql://test:test@localhost:5432/rent_test
+
+      - name: Seed invoice for unmatched reconciliation retry
+        run: |
+          psql -v ON_ERROR_STOP=1 "$DATABASE_URL" <<'SQL'
+          INSERT INTO invoices (
+            id, company_id, lease_id, owner_id, tenant_account_id,
+            invoice_number, status, issue_date, due_date, period_start,
+            period_end, subtotal, total_amount, balance_due, currency
+          ) VALUES (
+            'ffffffff-ffff-ffff-ffff-ffffffffffff',
+            '11111111-1111-1111-1111-111111111111',
+            '88888888-8888-8888-8888-888888888888',
+            '33333333-3333-3333-3333-333333333333',
+            '99999999-9999-9999-9999-999999999999',
+            'INV-BANK-RETRY-E2E', 'pending', CURRENT_DATE, CURRENT_DATE,
+            DATE_TRUNC('month', CURRENT_DATE)::date,
+            (DATE_TRUNC('month', CURRENT_DATE) + INTERVAL '1 month - 1 day')::date,
+            98765.00, 98765.00, 98765.00, 'ARS'
+          );
+
+          UPDATE tenant_accounts
+             SET current_balance = 98765.00
+           WHERE id = '99999999-9999-9999-9999-999999999999';
+          SQL
+        env:
+          DATABASE_URL: postgresql://test:test@localhost:5432/rent_test
+
+      - name: Retry unmatched bank reconciliation
+        working-directory: batch
+        run: >-
+          npm run dev -- reconcile-bank
+          --company-id 11111111-1111-1111-1111-111111111111
+          --limit 10
+          --min-age-minutes 0
+        env:
+          DATABASE_URL: postgresql://test:test@localhost:5432/rent_test
+          BACKEND_INTERNAL_URL: http://localhost:3001
+          BATCH_BANK_RECONCILIATION_INTERNAL_TOKEN: ci-bank-token
+          NODE_ENV: test
+
+      - name: Verify unmatched alert resolution
+        run: |
+          psql -v ON_ERROR_STOP=1 "$DATABASE_URL" <<'SQL'
+          DO $assert$
+          DECLARE
+            movement_status TEXT;
+            reconciliation_status TEXT;
+            invoice_status TEXT;
+            alert_status TEXT;
+            alert_resolved BOOLEAN;
+            payment_count INTEGER;
+          BEGIN
+            SELECT status INTO movement_status
+              FROM bank_movements
+             WHERE id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+            SELECT status INTO reconciliation_status
+              FROM bank_reconciliations
+             WHERE movement_id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+            SELECT status INTO invoice_status
+              FROM invoices
+             WHERE id = 'ffffffff-ffff-ffff-ffff-ffffffffffff';
+            SELECT status, resolved_at IS NOT NULL
+              INTO alert_status, alert_resolved
+              FROM bank_reconciliation_alerts
+             WHERE movement_id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+            SELECT COUNT(*) INTO payment_count
+              FROM payments
+             WHERE reference_number = 'ci-bank:ci-bank-unmatched-1'
+               AND status = 'completed';
+
+            IF movement_status <> 'reconciled'
+              OR reconciliation_status <> 'matched'
+              OR invoice_status <> 'paid'
+              OR alert_status <> 'resolved'
+              OR alert_resolved IS NOT TRUE
+              OR payment_count <> 1 THEN
+              RAISE EXCEPTION
+                'Unexpected retry state: movement %, reconciliation %, invoice %, alert %, resolved %, payments %',
+                movement_status, reconciliation_status, invoice_status,
+                alert_status, alert_resolved, payment_count;
+            END IF;
+          END $assert$;
+          SQL
+        env:
+          DATABASE_URL: postgresql://test:test@localhost:5432/rent_test
+
+      - name: Stop bank reconciliation backend
+        if: always()
+        run: |
+          if [ -f "$RUNNER_TEMP/rent-backend.pid" ]; then
+            kill "$(cat "$RUNNER_TEMP/rent-backend.pid")" 2>/dev/null || true
+          fi
+          if [ -f "$RUNNER_TEMP/rent-backend.log" ]; then
+            tail -100 "$RUNNER_TEMP/rent-backend.log"
+          fi
 
       - name: Run settlement integration flow
         working-directory: batch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,6 +483,48 @@ jobs:
           DATABASE_URL: postgresql://test:test@localhost:5432/rent_test
           NODE_ENV: test
 
+      - name: Run settlement integration flow
+        working-directory: batch
+        run: |
+          SETTLEMENT_PERIOD="$(date +%Y-%m)"
+          npm run dev -- process-settlements \
+            --owner-id 33333333-3333-3333-3333-333333333333 \
+            --period "$SETTLEMENT_PERIOD"
+          psql -v ON_ERROR_STOP=1 "$DATABASE_URL" <<'SQL'
+          DO $assert$
+          DECLARE
+            settlement_record settlements%ROWTYPE;
+          BEGIN
+            SELECT * INTO settlement_record
+            FROM settlements
+            WHERE owner_id = '33333333-3333-3333-3333-333333333333'::uuid
+              AND period = TO_CHAR(CURRENT_DATE, 'YYYY-MM');
+
+            IF NOT FOUND THEN
+              RAISE EXCEPTION 'Settlement was not persisted';
+            END IF;
+            IF settlement_record.status <> 'completed' THEN
+              RAISE EXCEPTION 'Unexpected settlement status: %', settlement_record.status;
+            END IF;
+            IF settlement_record.gross_amount <> 250000.00 THEN
+              RAISE EXCEPTION 'Unexpected gross amount: %', settlement_record.gross_amount;
+            END IF;
+            IF settlement_record.commission_amount <> 20000.00 THEN
+              RAISE EXCEPTION 'Unexpected commission: %', settlement_record.commission_amount;
+            END IF;
+            IF settlement_record.net_amount <> 230000.00 THEN
+              RAISE EXCEPTION 'Unexpected net amount: %', settlement_record.net_amount;
+            END IF;
+            IF settlement_record.transfer_reference IS NULL THEN
+              RAISE EXCEPTION 'Transfer reference was not recorded';
+            END IF;
+          END
+          $assert$;
+          SQL
+        env:
+          DATABASE_URL: postgresql://test:test@localhost:5432/rent_test
+          NODE_ENV: test
+
       - name: Seed bank reconciliation integration fixture
         run: |
           psql -v ON_ERROR_STOP=1 "$DATABASE_URL" <<'SQL'
@@ -726,48 +768,6 @@ jobs:
           if [ -f "$RUNNER_TEMP/rent-backend.log" ]; then
             tail -100 "$RUNNER_TEMP/rent-backend.log"
           fi
-
-      - name: Run settlement integration flow
-        working-directory: batch
-        run: |
-          SETTLEMENT_PERIOD="$(date +%Y-%m)"
-          npm run dev -- process-settlements \
-            --owner-id 33333333-3333-3333-3333-333333333333 \
-            --period "$SETTLEMENT_PERIOD"
-          psql -v ON_ERROR_STOP=1 "$DATABASE_URL" <<'SQL'
-          DO $assert$
-          DECLARE
-            settlement_record settlements%ROWTYPE;
-          BEGIN
-            SELECT * INTO settlement_record
-            FROM settlements
-            WHERE owner_id = '33333333-3333-3333-3333-333333333333'::uuid
-              AND period = TO_CHAR(CURRENT_DATE, 'YYYY-MM');
-
-            IF NOT FOUND THEN
-              RAISE EXCEPTION 'Settlement was not persisted';
-            END IF;
-            IF settlement_record.status <> 'completed' THEN
-              RAISE EXCEPTION 'Unexpected settlement status: %', settlement_record.status;
-            END IF;
-            IF settlement_record.gross_amount <> 250000.00 THEN
-              RAISE EXCEPTION 'Unexpected gross amount: %', settlement_record.gross_amount;
-            END IF;
-            IF settlement_record.commission_amount <> 20000.00 THEN
-              RAISE EXCEPTION 'Unexpected commission: %', settlement_record.commission_amount;
-            END IF;
-            IF settlement_record.net_amount <> 230000.00 THEN
-              RAISE EXCEPTION 'Unexpected net amount: %', settlement_record.net_amount;
-            END IF;
-            IF settlement_record.transfer_reference IS NULL THEN
-              RAISE EXCEPTION 'Transfer reference was not recorded';
-            END IF;
-          END
-          $assert$;
-          SQL
-        env:
-          DATABASE_URL: postgresql://test:test@localhost:5432/rent_test
-          NODE_ENV: test
 
   # ─────────────────────────────────────────────────────────────
   # FRONTEND JOBS

--- a/backend/src/bank-reconciliation/bank-reconciliation.controller.spec.ts
+++ b/backend/src/bank-reconciliation/bank-reconciliation.controller.spec.ts
@@ -1,14 +1,19 @@
 import { ForbiddenException } from '@nestjs/common';
 import { BankMovementDirection } from './entities/bank-movement.entity';
 import { BankReconciliationController } from './bank-reconciliation.controller';
+import { BankReconciliationAlertStatus } from './entities/bank-reconciliation-alert.entity';
 
 describe('BankReconciliationController', () => {
   const service = {
     ingestSandboxMovement: jest.fn(),
     reconcile: jest.fn(),
+    assertBatchToken: jest.fn(),
+    reconcileInternal: jest.fn(),
+    findAlerts: jest.fn(),
+    resolveAlert: jest.fn(),
   };
   const controller = new BankReconciliationController(service as any);
-  const request = { user: { companyId: 'company-1' } };
+  const request = { user: { id: 'user-1', companyId: 'company-1' } };
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -51,5 +56,39 @@ describe('BankReconciliationController', () => {
       id: 'result',
     });
     expect(service.reconcile).toHaveBeenCalledWith('movement-1', 'company-1');
+  });
+
+  it('authenticates and forwards internal batch retries', async () => {
+    service.reconcileInternal.mockResolvedValue({ id: 'result' });
+    await expect(
+      controller.reconcileFromBatch('movement-1', 'bank-token'),
+    ).resolves.toEqual({ id: 'result' });
+    expect(service.assertBatchToken).toHaveBeenCalledWith('bank-token');
+    expect(service.reconcileInternal).toHaveBeenCalledWith('movement-1');
+  });
+
+  it('lists and resolves alerts within the authenticated company', async () => {
+    service.findAlerts.mockResolvedValue([{ id: 'alert-1' }]);
+    await expect(
+      controller.findAlerts(request, BankReconciliationAlertStatus.OPEN),
+    ).resolves.toEqual([{ id: 'alert-1' }]);
+    expect(service.findAlerts).toHaveBeenCalledWith(
+      'company-1',
+      BankReconciliationAlertStatus.OPEN,
+    );
+
+    service.resolveAlert.mockResolvedValue({
+      id: 'alert-1',
+      status: 'resolved',
+    });
+    await expect(controller.resolveAlert(request, 'alert-1')).resolves.toEqual({
+      id: 'alert-1',
+      status: 'resolved',
+    });
+    expect(service.resolveAlert).toHaveBeenCalledWith(
+      'alert-1',
+      'company-1',
+      'user-1',
+    );
   });
 });

--- a/backend/src/bank-reconciliation/bank-reconciliation.controller.ts
+++ b/backend/src/bank-reconciliation/bank-reconciliation.controller.ts
@@ -2,18 +2,25 @@ import {
   Body,
   Controller,
   ForbiddenException,
+  Get,
+  Headers,
   Param,
+  ParseEnumPipe,
   ParseUUIDPipe,
+  Patch,
   Post,
+  Query,
   Request,
 } from '@nestjs/common';
+import { Public } from '../common/decorators/public.decorator';
 import { Roles } from '../common/decorators/roles.decorator';
 import { UserRole } from '../users/entities/user.entity';
 import { BankReconciliationService } from './bank-reconciliation.service';
 import { CreateSandboxBankMovementDto } from './dto/create-sandbox-bank-movement.dto';
+import { BankReconciliationAlertStatus } from './entities/bank-reconciliation-alert.entity';
 
 interface AuthenticatedRequest {
-  user: { companyId: string };
+  user: { id: string; companyId: string };
 }
 
 @Controller('bank-reconciliation')
@@ -38,5 +45,39 @@ export class BankReconciliationController {
     @Param('id', ParseUUIDPipe) id: string,
   ) {
     return this.service.reconcile(id, request.user.companyId);
+  }
+
+  @Public()
+  @Post('internal/movements/:id/reconcile')
+  reconcileFromBatch(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Headers('x-batch-bank-token') token?: string,
+  ) {
+    this.service.assertBatchToken(token);
+    return this.service.reconcileInternal(id);
+  }
+
+  @Get('alerts')
+  findAlerts(
+    @Request() request: AuthenticatedRequest,
+    @Query(
+      'status',
+      new ParseEnumPipe(BankReconciliationAlertStatus, { optional: true }),
+    )
+    status?: BankReconciliationAlertStatus,
+  ) {
+    return this.service.findAlerts(request.user.companyId, status);
+  }
+
+  @Patch('alerts/:id/resolve')
+  resolveAlert(
+    @Request() request: AuthenticatedRequest,
+    @Param('id', ParseUUIDPipe) id: string,
+  ) {
+    return this.service.resolveAlert(
+      id,
+      request.user.companyId,
+      request.user.id,
+    );
   }
 }

--- a/backend/src/bank-reconciliation/bank-reconciliation.module.ts
+++ b/backend/src/bank-reconciliation/bank-reconciliation.module.ts
@@ -6,6 +6,7 @@ import { PaymentsModule } from '../payments/payments.module';
 import { BankReconciliationController } from './bank-reconciliation.controller';
 import { BankReconciliationService } from './bank-reconciliation.service';
 import { BankReconciliation } from './entities/bank-reconciliation.entity';
+import { BankReconciliationAlert } from './entities/bank-reconciliation-alert.entity';
 import { BankMovement } from './entities/bank-movement.entity';
 
 @Module({
@@ -13,6 +14,7 @@ import { BankMovement } from './entities/bank-movement.entity';
     TypeOrmModule.forFeature([
       BankMovement,
       BankReconciliation,
+      BankReconciliationAlert,
       BankAccount,
       Invoice,
     ]),

--- a/backend/src/bank-reconciliation/bank-reconciliation.service.spec.ts
+++ b/backend/src/bank-reconciliation/bank-reconciliation.service.spec.ts
@@ -10,6 +10,7 @@ import {
 } from './entities/bank-movement.entity';
 import { InvoiceStatus } from '../payments/entities/invoice.entity';
 import { PaymentStatus } from '../payments/entities/payment.entity';
+import { BankReconciliationAlertStatus } from './entities/bank-reconciliation-alert.entity';
 
 const fluentQuery = (result: { one?: unknown; many?: unknown[] }) => {
   const query: Record<string, jest.Mock> = {};
@@ -39,6 +40,7 @@ describe('BankReconciliationService', () => {
   let reconciliations: any;
   let bankAccounts: any;
   let invoices: any;
+  let alerts: any;
   let payments: any;
   let dataSource: any;
   let service: BankReconciliationService;
@@ -94,6 +96,11 @@ describe('BankReconciliationService', () => {
       createQueryBuilder: jest.fn(),
     };
     invoices = { findOne: jest.fn(), createQueryBuilder: jest.fn() };
+    alerts = {
+      find: jest.fn(),
+      findOne: jest.fn(),
+      save: jest.fn(async (value) => value),
+    };
     payments = {
       create: jest.fn(),
       findOne: jest.fn(),
@@ -113,9 +120,77 @@ describe('BankReconciliationService', () => {
       reconciliations,
       bankAccounts,
       invoices,
+      alerts,
       payments,
       dataSource,
     );
+  });
+
+  it('protects batch reconciliation with a separately configured token', () => {
+    const previous = process.env.BATCH_BANK_RECONCILIATION_INTERNAL_TOKEN;
+    delete process.env.BATCH_BANK_RECONCILIATION_INTERNAL_TOKEN;
+    expect(() => service.assertBatchToken('token')).toThrow(
+      'token is not configured',
+    );
+    process.env.BATCH_BANK_RECONCILIATION_INTERNAL_TOKEN = 'expected';
+    expect(() => service.assertBatchToken()).toThrow('Invalid batch');
+    expect(() => service.assertBatchToken('wrong')).toThrow('Invalid batch');
+    expect(() => service.assertBatchToken('expected')).not.toThrow();
+    if (previous === undefined) {
+      delete process.env.BATCH_BANK_RECONCILIATION_INTERNAL_TOKEN;
+    } else {
+      process.env.BATCH_BANK_RECONCILIATION_INTERNAL_TOKEN = previous;
+    }
+  });
+
+  it('resolves company scope before an internal reconciliation', async () => {
+    const storedMovement = movement();
+    const matched = reconciliation({
+      status: BankReconciliationStatus.MATCHED,
+    });
+    movements.findOne
+      .mockResolvedValueOnce(storedMovement)
+      .mockResolvedValueOnce(storedMovement);
+    reconciliations.findOne
+      .mockResolvedValueOnce(matched)
+      .mockResolvedValueOnce(matched);
+    await expect(service.reconcileInternal(movementId)).resolves.toBe(matched);
+
+    movements.findOne.mockReset().mockResolvedValue(null);
+    await expect(service.reconcileInternal('missing')).rejects.toThrow(
+      'Bank movement not found',
+    );
+  });
+
+  it('lists and manually resolves company-scoped alerts', async () => {
+    const openAlert = {
+      id: 'alert-1',
+      companyId,
+      status: BankReconciliationAlertStatus.OPEN,
+      resolvedAt: null,
+      resolvedBy: null,
+    };
+    alerts.find.mockResolvedValue([openAlert]);
+    await expect(service.findAlerts(companyId)).resolves.toEqual([openAlert]);
+    expect(alerts.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          companyId,
+          status: BankReconciliationAlertStatus.OPEN,
+        },
+      }),
+    );
+
+    alerts.findOne.mockResolvedValue(openAlert);
+    const resolved = await service.resolveAlert('alert-1', companyId, 'user-1');
+    expect(resolved.status).toBe(BankReconciliationAlertStatus.RESOLVED);
+    expect(resolved.resolvedBy).toBe('user-1');
+    expect(resolved.resolvedAt).toBeInstanceOf(Date);
+
+    alerts.findOne.mockResolvedValue(null);
+    await expect(
+      service.resolveAlert('missing', companyId, 'user-1'),
+    ).rejects.toThrow('Bank reconciliation alert not found');
   });
 
   it('ingests, matches by virtual account, confirms and returns a receipt-bearing reconciliation', async () => {

--- a/backend/src/bank-reconciliation/bank-reconciliation.service.ts
+++ b/backend/src/bank-reconciliation/bank-reconciliation.service.ts
@@ -2,7 +2,10 @@ import {
   BadRequestException,
   Injectable,
   NotFoundException,
+  ServiceUnavailableException,
+  UnauthorizedException,
 } from '@nestjs/common';
+import { timingSafeEqual } from 'node:crypto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
 import { BankAccount } from '../bank-accounts/entities/bank-account.entity';
@@ -13,6 +16,10 @@ import {
 } from '../payments/entities/payment.entity';
 import { PaymentsService } from '../payments/payments.service';
 import { CreateSandboxBankMovementDto } from './dto/create-sandbox-bank-movement.dto';
+import {
+  BankReconciliationAlert,
+  BankReconciliationAlertStatus,
+} from './entities/bank-reconciliation-alert.entity';
 import {
   BankMatchStrategy,
   BankReconciliation,
@@ -43,9 +50,67 @@ export class BankReconciliationService {
     private readonly bankAccountsRepository: Repository<BankAccount>,
     @InjectRepository(Invoice)
     private readonly invoicesRepository: Repository<Invoice>,
+    @InjectRepository(BankReconciliationAlert)
+    private readonly alertsRepository: Repository<BankReconciliationAlert>,
     private readonly paymentsService: PaymentsService,
     private readonly dataSource: DataSource,
   ) {}
+
+  assertBatchToken(token?: string): void {
+    const expected =
+      process.env.BATCH_BANK_RECONCILIATION_INTERNAL_TOKEN?.trim() ?? '';
+    if (!expected) {
+      throw new ServiceUnavailableException(
+        'Batch bank reconciliation token is not configured',
+      );
+    }
+    const received = Buffer.from(token ?? '');
+    const configured = Buffer.from(expected);
+    if (
+      received.length !== configured.length ||
+      !timingSafeEqual(received, configured)
+    ) {
+      throw new UnauthorizedException(
+        'Invalid batch bank reconciliation token',
+      );
+    }
+  }
+
+  async reconcileInternal(movementId: string): Promise<BankReconciliation> {
+    const movement = await this.movementsRepository.findOne({
+      where: { id: movementId },
+    });
+    if (!movement) throw new NotFoundException('Bank movement not found');
+    return this.reconcile(movementId, movement.companyId);
+  }
+
+  findAlerts(
+    companyId: string,
+    status: BankReconciliationAlertStatus = BankReconciliationAlertStatus.OPEN,
+  ): Promise<BankReconciliationAlert[]> {
+    return this.alertsRepository.find({
+      where: { companyId, status },
+      relations: ['movement'],
+      order: { lastDetectedAt: 'DESC' },
+    });
+  }
+
+  async resolveAlert(
+    id: string,
+    companyId: string,
+    userId: string,
+  ): Promise<BankReconciliationAlert> {
+    const alert = await this.alertsRepository.findOne({
+      where: { id, companyId },
+    });
+    if (!alert) {
+      throw new NotFoundException('Bank reconciliation alert not found');
+    }
+    alert.status = BankReconciliationAlertStatus.RESOLVED;
+    alert.resolvedAt = new Date();
+    alert.resolvedBy = userId;
+    return this.alertsRepository.save(alert);
+  }
 
   async ingestSandboxMovement(
     companyId: string,

--- a/backend/src/bank-reconciliation/entities/bank-reconciliation-alert.entity.ts
+++ b/backend/src/bank-reconciliation/entities/bank-reconciliation-alert.entity.ts
@@ -1,0 +1,71 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Company } from '../../companies/entities/company.entity';
+import { User } from '../../users/entities/user.entity';
+import { BankMovement } from './bank-movement.entity';
+
+export enum BankReconciliationAlertStatus {
+  OPEN = 'open',
+  RESOLVED = 'resolved',
+}
+
+@Entity('bank_reconciliation_alerts')
+export class BankReconciliationAlert {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'company_id', type: 'uuid' })
+  companyId: string;
+
+  @ManyToOne(() => Company)
+  @JoinColumn({ name: 'company_id' })
+  company: Company;
+
+  @Column({ name: 'movement_id', type: 'uuid' })
+  movementId: string;
+
+  @ManyToOne(() => BankMovement)
+  @JoinColumn({ name: 'movement_id' })
+  movement: BankMovement;
+
+  @Column({ type: 'varchar', length: 20 })
+  status: BankReconciliationAlertStatus;
+
+  @Column({ type: 'text' })
+  reason: string;
+
+  @Column({ name: 'occurrence_count', type: 'integer', default: 1 })
+  occurrenceCount: number;
+
+  @Column({ name: 'first_detected_at', type: 'timestamptz' })
+  firstDetectedAt: Date;
+
+  @Column({ name: 'last_detected_at', type: 'timestamptz' })
+  lastDetectedAt: Date;
+
+  @Column({ name: 'resolved_at', type: 'timestamptz', nullable: true })
+  resolvedAt: Date | null;
+
+  @Column({ name: 'resolved_by', type: 'uuid', nullable: true })
+  resolvedBy: string | null;
+
+  @ManyToOne(() => User, { nullable: true })
+  @JoinColumn({ name: 'resolved_by' })
+  resolver: User | null;
+
+  @Column({ type: 'jsonb', default: {} })
+  metadata: Record<string, unknown>;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+  updatedAt: Date;
+}

--- a/backend/src/entity-metadata.spec.ts
+++ b/backend/src/entity-metadata.spec.ts
@@ -1,6 +1,9 @@
 import 'reflect-metadata';
 import { getMetadataArgsStorage } from 'typeorm';
+import { BankMovement } from './bank-reconciliation/entities/bank-movement.entity';
+import { BankReconciliationAlert } from './bank-reconciliation/entities/bank-reconciliation-alert.entity';
 import { Buyer } from './buyers/entities/buyer.entity';
+import { Company } from './companies/entities/company.entity';
 import { InterestedProfile } from './interested/entities/interested-profile.entity';
 import { LeaseContractTemplate } from './leases/entities/lease-contract-template.entity';
 import { User } from './users/entities/user.entity';
@@ -20,6 +23,19 @@ describe('Entity metadata', () => {
 
     expect(column).toBeDefined();
     expect(column?.options.type).toBe(expectedType);
+  };
+
+  const expectRelationTarget = (
+    entity: EntityClass,
+    propertyName: string,
+    expectedTarget: EntityClass,
+  ) => {
+    const relation = getMetadataArgsStorage().relations.find(
+      (item) => item.target === entity && item.propertyName === propertyName,
+    );
+
+    expect(relation).toBeDefined();
+    expect((relation?.type as () => EntityClass)()).toBe(expectedTarget);
   };
 
   it('defines explicit runtime-safe types for nullable string and UUID unions', () => {
@@ -53,5 +69,11 @@ describe('Entity metadata', () => {
       });
 
     expect(unsafeColumns).toEqual([]);
+  });
+
+  it('links bank reconciliation alerts to their scoped entities', () => {
+    expectRelationTarget(BankReconciliationAlert, 'company', Company);
+    expectRelationTarget(BankReconciliationAlert, 'movement', BankMovement);
+    expectRelationTarget(BankReconciliationAlert, 'resolver', User);
   });
 });

--- a/backend/test/payment-flow.e2e-spec.ts
+++ b/backend/test/payment-flow.e2e-spec.ts
@@ -199,6 +199,10 @@ describe('Payment accounting flow (e2e)', () => {
   afterAll(async () => {
     if (companyId) {
       await dataSource.query(
+        `DELETE FROM bank_reconciliation_alerts WHERE company_id = $1::uuid`,
+        [companyId],
+      );
+      await dataSource.query(
         `DELETE FROM bank_reconciliations WHERE company_id = $1::uuid`,
         [companyId],
       );
@@ -463,5 +467,89 @@ describe('Payment accounting flow (e2e)', () => {
     });
     expect(refreshedInvoice.status).toBe(InvoiceStatus.PAID);
     expect(Number(refreshedInvoice.amountPaid)).toBe(750);
+  });
+
+  it('protects batch retries and lets administrators review and resolve unmatched alerts', async () => {
+    expect.hasAssertions();
+    const internalToken = `bank-batch-${uniqueId}`;
+    process.env.BATCH_BANK_RECONCILIATION_INTERNAL_TOKEN = internalToken;
+
+    const unmatched = await request(app.getHttpServer())
+      .post('/bank-reconciliation/sandbox/movements')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        externalId: `sandbox-unmatched-${uniqueId}`,
+        direction: 'credit',
+        amount: 987654.32,
+        currency: 'ARS',
+        occurredAt: '2026-08-15T14:00:00.000Z',
+        description: 'Transferencia sin referencia identificable',
+      })
+      .expect(201);
+    expect(unmatched.body.status).toBe('unmatched');
+
+    await request(app.getHttpServer())
+      .post(
+        `/bank-reconciliation/internal/movements/${unmatched.body.movementId}/reconcile`,
+      )
+      .set('x-batch-bank-token', 'invalid-token')
+      .expect(401);
+
+    const retried = await request(app.getHttpServer())
+      .post(
+        `/bank-reconciliation/internal/movements/${unmatched.body.movementId}/reconcile`,
+      )
+      .set('x-batch-bank-token', internalToken)
+      .expect(201);
+    expect(retried.body).toMatchObject({
+      id: unmatched.body.id,
+      movementId: unmatched.body.movementId,
+      status: 'unmatched',
+    });
+
+    const [alert] = await dataSource.query(
+      `INSERT INTO bank_reconciliation_alerts (
+         company_id, movement_id, reason, metadata
+       ) VALUES ($1::uuid, $2::uuid, $3, $4::jsonb)
+       RETURNING id`,
+      [
+        companyId,
+        unmatched.body.movementId,
+        'No unique pending invoice matched the movement',
+        JSON.stringify({ source: 'reconcile-bank-e2e' }),
+      ],
+    );
+
+    const openAlerts = await request(app.getHttpServer())
+      .get('/bank-reconciliation/alerts')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(200);
+    expect(openAlerts.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: alert.id,
+          movementId: unmatched.body.movementId,
+          status: 'open',
+        }),
+      ]),
+    );
+
+    const resolved = await request(app.getHttpServer())
+      .patch(`/bank-reconciliation/alerts/${alert.id}/resolve`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(200);
+    expect(resolved.body).toMatchObject({ id: alert.id, status: 'resolved' });
+    expect(resolved.body.resolvedAt).toBeTruthy();
+    expect(resolved.body.resolvedBy).toBeTruthy();
+
+    const resolvedAlerts = await request(app.getHttpServer())
+      .get('/bank-reconciliation/alerts?status=resolved')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(200);
+    expect(resolvedAlerts.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: alert.id, status: 'resolved' }),
+      ]),
+    );
   });
 });

--- a/batch/src/index.ts
+++ b/batch/src/index.ts
@@ -7,7 +7,7 @@ if (process.env.NEW_RELIC_LICENSE_KEY) {
 
 import "reflect-metadata";
 import { config } from "dotenv";
-import { Command } from "commander";
+import { Command, InvalidArgumentError } from "commander";
 import { SpanStatusCode, trace } from "@opentelemetry/api";
 import type { BillingJobService } from "./services/billing-job.service";
 import { batchMetrics } from "./shared/metrics";
@@ -53,6 +53,28 @@ let closeDatabase: () => Promise<void> = async () => {
 
 const program = new Command();
 const tracer = trace.getTracer("rent-batch-cli");
+
+function positiveInteger(value: string): number {
+  if (!/^\d+$/.test(value)) {
+    throw new InvalidArgumentError("Must be a positive integer");
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new InvalidArgumentError("Must be a positive integer");
+  }
+  return parsed;
+}
+
+function nonNegativeInteger(value: string): number {
+  if (!/^\d+$/.test(value)) {
+    throw new InvalidArgumentError("Must be a non-negative integer");
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new InvalidArgumentError("Must be a non-negative integer");
+  }
+  return parsed;
+}
 
 // Import logger after potential `process.env.LOG_FILE` is set.
 // Use dynamic import inside main() so ESLint does not complain about require().
@@ -1109,6 +1131,84 @@ program
  * T882: Settlement Command
  * T883: Settlement scheduled date logic (5th business day)
  */
+program
+  .command("reconcile-bank")
+  .description("Retry pending bank movements and create unmatched alerts")
+  .option("--log <file>", "Write logs to the given file (no rotation)")
+  .option("--company-id <id>", "Restrict reconciliation to one company")
+  .option(
+    "--limit <count>",
+    "Maximum movements to process",
+    positiveInteger,
+    100,
+  )
+  .option(
+    "--min-age-minutes <minutes>",
+    "Only process movements at least this old",
+    nonNegativeInteger,
+    5,
+  )
+  .option("-d, --dry-run", "Select movements without reconciling", false)
+  .action(
+    withTracedAction("reconcile-bank", async (options) => {
+      const { BankReconciliationBatchService } =
+        await import("./services/bank-reconciliation.service");
+      const startedAtNs = process.hrtime.bigint();
+      let jobId: string | undefined;
+      let metricsSummary:
+        | {
+            recordsTotal: number;
+            recordsProcessed: number;
+            recordsFailed: number;
+          }
+        | undefined;
+
+      try {
+        await initializeDatabase();
+        billingJobService = newBillingJobService();
+        jobId = await billingJobService.startJob(
+          "reconcile_bank",
+          {
+            companyId: options.companyId,
+            limit: options.limit,
+            minAgeMinutes: options.minAgeMinutes,
+          },
+          options.dryRun,
+        );
+
+        const summary = await new BankReconciliationBatchService().process({
+          companyId: options.companyId,
+          limit: options.limit,
+          minAgeMinutes: options.minAgeMinutes,
+          dryRun: options.dryRun,
+        });
+        metricsSummary = summary;
+        await billingJobService.completeJob(jobId, summary);
+        logger.info("Reconcile-bank completed", summary);
+        await batchMetrics.recordJobRun({
+          job: "reconcile_bank",
+          status: "success",
+          startedAtNs,
+          summary: metricsSummary,
+        });
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Unknown error";
+        logger.error("Reconcile-bank failed", { error: message });
+        if (jobId) await billingJobService.failJob(jobId, message);
+        await batchMetrics.recordJobRun({
+          job: "reconcile_bank",
+          status: "failed",
+          startedAtNs,
+          summary: metricsSummary,
+        });
+        process.exitCode = 1;
+      } finally {
+        await closeDatabase();
+      }
+    }),
+  );
+
 program
   .command("process-settlements")
   .description("Calculate and process settlements for property owners")

--- a/batch/src/services/bank-reconciliation.service.spec.ts
+++ b/batch/src/services/bank-reconciliation.service.spec.ts
@@ -1,0 +1,181 @@
+jest.mock("../shared/database", () => ({
+  AppDataSource: { query: jest.fn() },
+}));
+jest.mock("../shared/logger", () => ({
+  logger: { info: jest.fn(), error: jest.fn() },
+}));
+
+import { AppDataSource } from "../shared/database";
+import { BankReconciliationBatchService } from "./bank-reconciliation.service";
+
+describe("BankReconciliationBatchService", () => {
+  const originalEnv = process.env;
+  const query = AppDataSource.query as jest.Mock;
+  const fetchMock = jest.fn();
+
+  const candidate = (id: string) => ({
+    id,
+    company_id: "10000000-0000-0000-0000-000000000001",
+    provider: "sandbox",
+    external_id: `external-${id}`,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      BACKEND_INTERNAL_URL: "http://backend.internal/",
+      BATCH_BANK_RECONCILIATION_INTERNAL_TOKEN: "bank-token",
+    };
+    Object.defineProperty(global, "fetch", {
+      writable: true,
+      value: fetchMock,
+    });
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("selects candidates without side effects in dry-run mode", async () => {
+    query.mockResolvedValue([candidate("movement-1")]);
+    const service = new BankReconciliationBatchService();
+
+    await expect(
+      service.process({ limit: 25, minAgeMinutes: 10, dryRun: true }),
+    ).resolves.toEqual({
+      recordsTotal: 1,
+      recordsProcessed: 0,
+      recordsFailed: 0,
+      recordsSkipped: 1,
+      alertsOpened: 0,
+      alertsResolved: 0,
+      errorLog: [],
+    });
+    expect(query).toHaveBeenCalledWith(expect.stringContaining("LIMIT $1"), [
+      25,
+      10,
+      null,
+    ]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("requires a separate internal token for live processing", async () => {
+    delete process.env.BATCH_BANK_RECONCILIATION_INTERNAL_TOKEN;
+    query.mockResolvedValue([candidate("movement-1")]);
+    const service = new BankReconciliationBatchService();
+
+    await expect(
+      service.process({ limit: 1, minAgeMinutes: 0, dryRun: false }),
+    ).rejects.toThrow(
+      "BATCH_BANK_RECONCILIATION_INTERNAL_TOKEN not configured",
+    );
+  });
+
+  it("processes matches, opens unmatched alerts and records request failures", async () => {
+    query
+      .mockResolvedValueOnce([
+        candidate("matched"),
+        candidate("unmatched"),
+        candidate("failed"),
+      ])
+      .mockResolvedValueOnce([[{ id: "resolved-alert" }], 1])
+      .mockResolvedValueOnce([{ inserted: true }])
+      .mockResolvedValueOnce([{ inserted: false }]);
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ status: "matched", paymentId: "payment-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ status: "unmatched", reason: "No invoice" }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({ message: "backend unavailable" }),
+      });
+    const service = new BankReconciliationBatchService();
+
+    const summary = await service.process({
+      companyId: "10000000-0000-0000-0000-000000000001",
+      limit: 100,
+      minAgeMinutes: 5,
+      dryRun: false,
+    });
+
+    expect(summary).toEqual({
+      recordsTotal: 3,
+      recordsProcessed: 1,
+      recordsFailed: 1,
+      recordsSkipped: 1,
+      alertsOpened: 1,
+      alertsResolved: 1,
+      errorLog: [{ movementId: "failed", error: "backend unavailable" }],
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://backend.internal/bank-reconciliation/internal/movements/matched/reconcile",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-batch-bank-token": "bank-token",
+        },
+      },
+    );
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO bank_reconciliation_alerts"),
+      expect.arrayContaining(["No invoice"]),
+    );
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("status = 'resolved'"),
+      ["matched"],
+    );
+  });
+
+  it("uses safe fallbacks for an empty successful response", async () => {
+    query
+      .mockResolvedValueOnce([candidate("unknown")])
+      .mockResolvedValueOnce([{ inserted: "t" }]);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+
+    const result = await new BankReconciliationBatchService().process({
+      limit: 1,
+      minAgeMinutes: 0,
+      dryRun: false,
+    });
+
+    expect(result.recordsSkipped).toBe(1);
+    expect(result.alertsOpened).toBe(1);
+    expect(query).toHaveBeenLastCalledWith(
+      expect.stringContaining("ON CONFLICT (movement_id)"),
+      expect.arrayContaining(["Movement remains unmatched after retry"]),
+    );
+  });
+
+  it("falls back to HTTP status when an error response has no JSON body", async () => {
+    query
+      .mockResolvedValueOnce([candidate("http-error")])
+      .mockResolvedValueOnce([{ inserted: false }]);
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: async () => {
+        throw new Error("invalid json");
+      },
+    });
+
+    const result = await new BankReconciliationBatchService().process({
+      limit: 1,
+      minAgeMinutes: 0,
+      dryRun: false,
+    });
+    expect(result.errorLog).toEqual([
+      { movementId: "http-error", error: "HTTP 502" },
+    ]);
+  });
+});

--- a/batch/src/services/bank-reconciliation.service.spec.ts
+++ b/batch/src/services/bank-reconciliation.service.spec.ts
@@ -72,6 +72,30 @@ describe("BankReconciliationBatchService", () => {
     );
   });
 
+  it("uses the default backend URL and reports no resolved alert when none exists", async () => {
+    delete process.env.BACKEND_INTERNAL_URL;
+    delete process.env.BACKEND_PORT;
+    query
+      .mockResolvedValueOnce([candidate("default-url")])
+      .mockResolvedValueOnce([[], 0]);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: "matched", paymentId: "payment-1" }),
+    });
+
+    const result = await new BankReconciliationBatchService().process({
+      limit: 1,
+      minAgeMinutes: 0,
+      dryRun: false,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3001/bank-reconciliation/internal/movements/default-url/reconcile",
+      expect.any(Object),
+    );
+    expect(result.alertsResolved).toBe(0);
+  });
+
   it("processes matches, opens unmatched alerts and records request failures", async () => {
     query
       .mockResolvedValueOnce([

--- a/batch/src/services/bank-reconciliation.service.ts
+++ b/batch/src/services/bank-reconciliation.service.ts
@@ -1,0 +1,201 @@
+import { AppDataSource } from "../shared/database";
+import { logger } from "../shared/logger";
+
+export interface ReconcileBankOptions {
+  limit: number;
+  minAgeMinutes: number;
+  companyId?: string;
+  dryRun: boolean;
+}
+
+export interface ReconcileBankSummary {
+  recordsTotal: number;
+  recordsProcessed: number;
+  recordsFailed: number;
+  recordsSkipped: number;
+  alertsOpened: number;
+  alertsResolved: number;
+  errorLog: object[];
+}
+
+interface BankMovementCandidate {
+  id: string;
+  company_id: string;
+  provider: string;
+  external_id: string;
+}
+
+interface ReconciliationResponse {
+  status?: string;
+  reason?: string | null;
+  paymentId?: string | null;
+}
+
+export class BankReconciliationBatchService {
+  private readonly backendUrl = (
+    process.env.BACKEND_INTERNAL_URL ??
+    `http://localhost:${process.env.BACKEND_PORT ?? "3001"}`
+  ).replace(/\/$/, "");
+  private readonly internalToken =
+    process.env.BATCH_BANK_RECONCILIATION_INTERNAL_TOKEN?.trim() ?? "";
+
+  async process(options: ReconcileBankOptions): Promise<ReconcileBankSummary> {
+    const candidates = await this.findCandidates(options);
+    const summary: ReconcileBankSummary = {
+      recordsTotal: candidates.length,
+      recordsProcessed: 0,
+      recordsFailed: 0,
+      recordsSkipped: 0,
+      alertsOpened: 0,
+      alertsResolved: 0,
+      errorLog: [],
+    };
+
+    if (options.dryRun) {
+      summary.recordsSkipped = candidates.length;
+      logger.info("Dry run: bank movements selected for reconciliation", {
+        count: candidates.length,
+      });
+      return summary;
+    }
+    if (!this.internalToken) {
+      throw new Error(
+        "BATCH_BANK_RECONCILIATION_INTERNAL_TOKEN not configured",
+      );
+    }
+
+    for (const movement of candidates) {
+      await this.processCandidate(movement, summary);
+    }
+    return summary;
+  }
+
+  private async findCandidates(
+    options: ReconcileBankOptions,
+  ): Promise<BankMovementCandidate[]> {
+    return AppDataSource.query(
+      `SELECT movement.id, movement.company_id, movement.provider,
+              movement.external_id
+         FROM bank_movements movement
+         LEFT JOIN bank_reconciliations reconciliation
+           ON reconciliation.movement_id = movement.id
+        WHERE movement.direction = 'credit'
+          AND movement.status IN ('pending', 'unmatched')
+          AND movement.occurred_at <= NOW() - ($2 * INTERVAL '1 minute')
+          AND ($3::uuid IS NULL OR movement.company_id = $3::uuid)
+          AND (
+            reconciliation.id IS NULL
+            OR reconciliation.status IN ('processing', 'unmatched', 'failed')
+          )
+        ORDER BY movement.occurred_at ASC, movement.id ASC
+        LIMIT $1`,
+      [options.limit, options.minAgeMinutes, options.companyId ?? null],
+    );
+  }
+
+  private async processCandidate(
+    movement: BankMovementCandidate,
+    summary: ReconcileBankSummary,
+  ): Promise<void> {
+    try {
+      const result = await this.requestReconciliation(movement.id);
+      if (result.status === "matched") {
+        summary.recordsProcessed += 1;
+        summary.alertsResolved += await this.resolveAlert(movement.id);
+        return;
+      }
+
+      const reason =
+        result.reason?.trim() || "Movement remains unmatched after retry";
+      summary.recordsSkipped += 1;
+      summary.alertsOpened += await this.openAlert(movement, reason, {
+        reconciliationStatus: result.status ?? "unknown",
+      });
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      summary.recordsFailed += 1;
+      summary.errorLog.push({ movementId: movement.id, error: reason });
+      summary.alertsOpened += await this.openAlert(movement, reason, {
+        reconciliationStatus: "request_failed",
+      });
+      logger.error("Bank movement reconciliation failed", {
+        movementId: movement.id,
+        error: reason,
+      });
+    }
+  }
+
+  private async requestReconciliation(
+    movementId: string,
+  ): Promise<ReconciliationResponse> {
+    const response = await fetch(
+      `${this.backendUrl}/bank-reconciliation/internal/movements/${movementId}/reconcile`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-batch-bank-token": this.internalToken,
+        },
+      },
+    );
+    const body = (await response.json().catch(() => ({}))) as Record<
+      string,
+      unknown
+    >;
+    if (!response.ok) {
+      const message = body.message ?? body.error ?? `HTTP ${response.status}`;
+      throw new Error(String(message));
+    }
+    return body as ReconciliationResponse;
+  }
+
+  private async openAlert(
+    movement: BankMovementCandidate,
+    reason: string,
+    metadata: Record<string, unknown>,
+  ): Promise<number> {
+    const [row] = await AppDataSource.query(
+      `INSERT INTO bank_reconciliation_alerts (
+         company_id, movement_id, status, reason, metadata
+       ) VALUES ($1, $2, 'open', $3, $4::jsonb)
+       ON CONFLICT (movement_id) DO UPDATE
+         SET status = 'open',
+             reason = EXCLUDED.reason,
+             occurrence_count = bank_reconciliation_alerts.occurrence_count + 1,
+             last_detected_at = NOW(),
+             resolved_at = NULL,
+             resolved_by = NULL,
+             metadata = EXCLUDED.metadata,
+             updated_at = NOW()
+       RETURNING (xmax = 0) AS inserted`,
+      [
+        movement.company_id,
+        movement.id,
+        reason,
+        JSON.stringify({
+          source: "reconcile-bank",
+          provider: movement.provider,
+          externalId: movement.external_id,
+          ...metadata,
+        }),
+      ],
+    );
+    return row?.inserted === true || row?.inserted === "t" ? 1 : 0;
+  }
+
+  private async resolveAlert(movementId: string): Promise<number> {
+    const result = await AppDataSource.query(
+      `UPDATE bank_reconciliation_alerts
+          SET status = 'resolved',
+              resolved_at = NOW(),
+              resolved_by = NULL,
+              updated_at = NOW()
+        WHERE movement_id = $1
+          AND status = 'open'
+      RETURNING id`,
+      [movementId],
+    );
+    const rows = Array.isArray(result[0]) ? result[0] : result;
+    return rows.length > 0 ? 1 : 0;
+  }
+}

--- a/batch/src/services/billing-job.service.ts
+++ b/batch/src/services/billing-job.service.ts
@@ -12,7 +12,8 @@ export type BillingJobType =
   | "sync_indices"
   | "reports"
   | "exchange_rates"
-  | "process_settlements";
+  | "process_settlements"
+  | "reconcile_bank";
 
 /**
  * Status of a billing job.

--- a/docs/plan-de-trabajo.md
+++ b/docs/plan-de-trabajo.md
@@ -745,16 +745,17 @@ Implementar sistema de cobranza multicanal y liquidación a propietarios.
 
 ### 8.5 Conciliación
 
-- 🔄 **T851**: Servicio de conciliación (EN PROGRESO)
+- ✅ **T851**: Servicio de conciliación
   - ✅ BankReconciliationService idempotente y aislado por compañía
   - ✅ Matching por alias/propiedad
   - ✅ Matching único por monto/fecha
-  - ⏳ Alertas de no conciliados
+  - ✅ Alertas operativas idempotentes de no conciliados, con revisión y resolución
 
-- **T852**: Comando `reconcile-bank`
-  - Procesar movimientos bancarios
-  - Match con pagos pendientes
-  - Generar alertas
+- ✅ **T852**: Comando `reconcile-bank`
+  - ✅ Procesar y reintentar movimientos bancarios pendientes
+  - ✅ Match contable mediante el backend y confirmación de pagos
+  - ✅ Generar y resolver alertas persistentes
+  - ✅ Flujo integrado batch → backend → pago/factura/recibo en CI
 
 ### 8.6 Cuenta Corriente
 
@@ -797,11 +798,11 @@ Implementar sistema de cobranza multicanal y liquidación a propietarios.
 
 ### 8.9 Testing Cobranzas
 
-- 🔄 **T891**: Tests unitarios servicios (EN PROGRESO)
+- ✅ **T891**: Tests unitarios servicios
   - ✅ Tests de PaymentService
   - ✅ Tests de SettlementService
   - ✅ Mocks de MercadoPago
-  - ⏳ Mocks de bancos
+  - ✅ Mocks de conciliación bancaria neutral y del backend interno
 
 - ✅ **T892**: Tests de integración
   - ✅ Flujo completo de pago: confirmación, cuenta corriente, factura, recibo y PDF
@@ -824,8 +825,8 @@ Implementar sistema de cobranza multicanal y liquidación a propietarios.
 # Procesar webhooks (cada 5 min)
 */5 * * * * cd /opt/rent/batch && npm start -- process-payments
 
-# Conciliación bancaria (diario 8:00)
-0 8 * * * cd /opt/rent/batch && npm start -- reconcile-bank
+# Conciliación bancaria (cada 10 min; reintenta movimientos con 5 min de antigüedad)
+*/10 * * * * cd /opt/rent/batch && npm start -- reconcile-bank --min-age-minutes 5
 
 # Verificar crypto (cada 15 min)
 */15 * * * * cd /opt/rent/batch && npm start -- check-crypto

--- a/docs/technical/payments.md
+++ b/docs/technical/payments.md
@@ -31,8 +31,19 @@ concurrentes y evita pagos duplicados.
 Para desarrollo y CI existe `POST /bank-reconciliation/sandbox/movements`. El
 endpoint está deshabilitado cuando `NODE_ENV=production`; no representa un
 webhook productivo ni llama a Bind o Pomelo. Los movimientos no conciliados se
-persisten para revisión, pero sus alertas y el comando batch `reconcile-bank`
-siguen pendientes.
+persisten para revisión.
+
+El comando batch `reconcile-bank` reintenta créditos pendientes o no
+conciliados, respetando antigüedad mínima, límite y compañía opcional. La
+contabilidad se ejecuta exclusivamente en el backend mediante un endpoint
+interno autenticado; el batch no duplica la lógica de pagos. Un movimiento que
+continúa sin match crea o actualiza una alerta operativa idempotente. Si un
+reintento posterior concilia el movimiento, la alerta abierta se resuelve
+automáticamente.
+
+Los administradores y miembros de staff pueden consultar estas alertas con
+`GET /bank-reconciliation/alerts?status=open` y resolver una revisión manual con
+`PATCH /bank-reconciliation/alerts/:id/resolve`.
 
 ## Flujo MercadoPago
 
@@ -56,6 +67,8 @@ MERCADOPAGO_ACCESS_TOKEN=...
 MERCADOPAGO_WEBHOOK_SECRET=...
 MERCADOPAGO_WEBHOOK_TOLERANCE_SECONDS=300
 APP_URL=https://rent.example.com/api
+BATCH_BANK_RECONCILIATION_INTERNAL_TOKEN=...
+BACKEND_INTERNAL_URL=http://backend:3001
 ```
 
 La clave de webhook se obtiene en MercadoPago Developers, dentro de la
@@ -81,6 +94,8 @@ La unicidad de alias bancarios activos se incorpora en
 `migrations/092_enforce_active_bank_alias_uniqueness.sql`.
 Las tablas `bank_movements` y `bank_reconciliations` se incorporan en
 `migrations/093_add_bank_movement_reconciliation.sql`.
+El tipo de job y `bank_reconciliation_alerts` se incorporan en
+`migrations/094_add_bank_reconciliation_alerts_and_batch_job.sql`.
 
 Validación local de la cadena completa:
 
@@ -90,6 +105,18 @@ cd backend
 npm run test:e2e -- --runInBand payment-gateway.e2e-spec.ts
 npm run test:e2e -- --runInBand payment-flow.e2e-spec.ts
 ```
+
+Ejecución operativa:
+
+```bash
+cd batch
+npm start -- reconcile-bank --limit 100 --min-age-minutes 5
+npm start -- reconcile-bank --company-id <uuid> --dry-run
+```
+
+La frecuencia recomendada es cada diez minutos. El token interno debe ser un
+secreto largo, distinto de JWT y credenciales bancarias, compartido solamente
+entre batch y backend.
 
 ## Salida a producción
 

--- a/migrations/094_add_bank_reconciliation_alerts_and_batch_job.sql
+++ b/migrations/094_add_bank_reconciliation_alerts_and_batch_job.sql
@@ -1,0 +1,31 @@
+-- Batch reconciliation job and persistent unmatched-movement alerts.
+
+ALTER TYPE billing_job_type ADD VALUE IF NOT EXISTS 'reconcile_bank';
+
+CREATE TABLE IF NOT EXISTS bank_reconciliation_alerts (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+    movement_id UUID NOT NULL REFERENCES bank_movements(id) ON DELETE CASCADE,
+    status VARCHAR(20) NOT NULL DEFAULT 'open'
+        CHECK (status IN ('open', 'resolved')),
+    reason TEXT NOT NULL,
+    occurrence_count INTEGER NOT NULL DEFAULT 1 CHECK (occurrence_count > 0),
+    first_detected_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_detected_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    resolved_at TIMESTAMPTZ,
+    resolved_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_bank_reconciliation_alerts_movement UNIQUE (movement_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_bank_reconciliation_alerts_open
+    ON bank_reconciliation_alerts(company_id, last_detected_at DESC)
+    WHERE status = 'open';
+
+DROP TRIGGER IF EXISTS update_bank_reconciliation_alerts_updated_at
+    ON bank_reconciliation_alerts;
+CREATE TRIGGER update_bank_reconciliation_alerts_updated_at
+    BEFORE UPDATE ON bank_reconciliation_alerts
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/scripts/init-db.sql
+++ b/scripts/init-db.sql
@@ -351,7 +351,7 @@ CREATE TYPE payment_document_template_type AS ENUM ('receipt', 'invoice', 'credi
 
 -- Billing job types
 CREATE TYPE billing_job_type AS ENUM (
-    'billing', 'overdue', 'reminders', 'late_fees', 'sync_indices', 'reports', 'exchange_rates', 'process_settlements'
+    'billing', 'overdue', 'reminders', 'late_fees', 'sync_indices', 'reports', 'exchange_rates', 'process_settlements', 'reconcile_bank'
 );
 
 -- Billing job status
@@ -2682,6 +2682,29 @@ CREATE INDEX idx_bank_reconciliations_company_status
     ON bank_reconciliations(company_id, status, created_at DESC);
 CREATE TRIGGER update_bank_reconciliations_updated_at
     BEFORE UPDATE ON bank_reconciliations FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TABLE bank_reconciliation_alerts (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+    movement_id UUID NOT NULL UNIQUE REFERENCES bank_movements(id) ON DELETE CASCADE,
+    status VARCHAR(20) NOT NULL DEFAULT 'open'
+        CHECK (status IN ('open', 'resolved')),
+    reason TEXT NOT NULL,
+    occurrence_count INTEGER NOT NULL DEFAULT 1 CHECK (occurrence_count > 0),
+    first_detected_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_detected_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    resolved_at TIMESTAMPTZ,
+    resolved_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_bank_reconciliation_alerts_open
+    ON bank_reconciliation_alerts(company_id, last_detected_at DESC)
+    WHERE status = 'open';
+CREATE TRIGGER update_bank_reconciliation_alerts_updated_at
+    BEFORE UPDATE ON bank_reconciliation_alerts
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
 -- -----------------------------------------------------------------------------
 -- Crypto Wallets (T812)


### PR DESCRIPTION
## Qué cambia

- incorpora la migración 094 y alertas persistentes e idempotentes para movimientos bancarios no conciliados
- agrega el comando `reconcile-bank` con filtros por compañía, límite, antigüedad mínima y dry-run
- mantiene la contabilidad en el backend mediante un endpoint interno autenticado y comparación de token en tiempo constante
- permite listar y resolver alertas por compañía
- agrega E2E batch → backend → PostgreSQL para match, pago, factura, recibo, apertura de alerta y resolución posterior
- actualiza variables de entorno, snapshot de base, documentación y T851/T852/T891

## Por qué

Cierra el circuito neutral de conciliación bancaria sin duplicar la lógica contable en batch y deja observabilidad operativa para transferencias que no encuentran una factura única.

## Validación

- backend: 111 suites / 880 tests; 91.38% statements, 75.38% branches
- batch: 18 suites / 149 tests; 92.37% statements, 75.89% branches
- backend E2E: 9 suites / 55 tests
- migraciones 091–094 aplicadas sobre snapshot limpio
- flujo local real: unmatched → alerta abierta → factura disponible → pago confirmado y alerta resuelta
- type-check, lint, format y build verdes
